### PR TITLE
fix(git): use absolute path for gh credential helper

### DIFF
--- a/home/base/tui/git.nix
+++ b/home/base/tui/git.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   ...
 }:
 {
@@ -11,19 +12,19 @@
     "https://github.com" = {
       helper = [
         ""
-        "!gh auth git-credential"
+        "!${pkgs.gh}/bin/gh auth git-credential"
       ];
     };
     "https://gist.github.com" = {
       helper = [
         ""
-        "!gh auth git-credential"
+        "!${pkgs.gh}/bin/gh auth git-credential"
       ];
     };
     "https://mirrors.tuna.tsinghua.edu.cn" = {
       helper = [
         ""
-        "!gh auth git-credential"
+        "!${pkgs.gh}/bin/gh auth git-credential"
       ];
     };
   };


### PR DESCRIPTION
## Summary
- use absolute path for `gh auth git-credential`
- avoid PATH-dependent failures in git/brew subprocesses

## Testing
- not run