### PR TITLE
🐛 fix(secrets): 用 GH_TOKEN 自动补齐 gh 登录态

### DIFF
--- a/home/base/core/secrets.nix
+++ b/home/base/core/secrets.nix
@@ -40,7 +40,11 @@ in
     let
       shellInit = ''
         export GH_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
-        export GITHUB_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
+        export GITHUB_TOKEN="$GH_TOKEN"
+        # 如果没有 login session，用 token 做一次 login
+        if ! gh auth status --hostname github.com &>/dev/null; then
+          echo "$GH_TOKEN" | gh auth login --with-token
+        fi
         # ai api key
         export CONTEXT7_API_KEY="$(cat ${config.sops.secrets."context7/api-key".path})"
         export DEEPSEEK_API_KEY="$(cat ${config.sops.secrets."deepseek/api-key".path})"


### PR DESCRIPTION
## Summary
- 在 shell 初始化时导出 GH_TOKEN 和 GITHUB_TOKEN
- 当 gh 未登录时，使用 GH_TOKEN 自动执行 `gh auth login --with-token`
- 避免 `gh auth git-credential` 在缺少登录态时回退为交互认证

## Testing
- not run