### PR TITLE
🐛 fix(secrets): 增加 HOMEBREW_GITHUB_API_TOKEN 导出

### DIFF
--- a/home/base/core/secrets.nix
+++ b/home/base/core/secrets.nix
@@ -41,6 +41,7 @@ in
       shellInit = ''
         export GH_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
         export GITHUB_TOKEN="$GH_TOKEN"
+        export HOMEBREW_GITHUB_API_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
         # 如果没有 login session，用 token 做一次 login
         if ! gh auth status --hostname github.com &>/dev/null; then
           echo "$GH_TOKEN" | gh auth login --with-token


### PR DESCRIPTION
## Summary
- 在 shellInit 中新增 `HOMEBREW_GITHUB_API_TOKEN` 导出
- 与 GH_TOKEN 使用同一 sops 密钥来源

## Testing
- not run