### PR TITLE
⏪ revert(secrets): 回退 GH_TOKEN 自动登录 gh

### DIFF
--- a/home/base/core/secrets.nix
+++ b/home/base/core/secrets.nix
@@ -40,12 +40,8 @@ in
     let
       shellInit = ''
         export GH_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
-        export GITHUB_TOKEN="$GH_TOKEN"
+        export GITHUB_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
         export HOMEBREW_GITHUB_API_TOKEN="$(cat ${config.sops.secrets."github/cli-token".path})"
-        # 如果没有 login session，用 token 做一次 login
-        if ! gh auth status --hostname github.com &>/dev/null; then
-          echo "$GH_TOKEN" | gh auth login --with-token
-        fi
         # ai api key
         export CONTEXT7_API_KEY="$(cat ${config.sops.secrets."context7/api-key".path})"
         export DEEPSEEK_API_KEY="$(cat ${config.sops.secrets."deepseek/api-key".path})"


### PR DESCRIPTION
## Summary
- 回退 #7 引入的 gh 自动登录逻辑
- 保留 `GH_TOKEN`、`GITHUB_TOKEN` 与 `HOMEBREW_GITHUB_API_TOKEN` 导出

## Testing
- not run