### PR TITLE
feat(wm): add OmniWM configuration

### DIFF
--- a/home/darwin/wm/default.nix
+++ b/home/darwin/wm/default.nix
@@ -2,5 +2,6 @@
 {
   imports = [
     ./aerospace.nix
+    ./omniwm.nix
   ];
 }

--- a/home/darwin/wm/omniwm.nix
+++ b/home/darwin/wm/omniwm.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  mylib,
+  config,
+  ...
+}:
+let
+  inherit (lib) mkIf;
+  inherit (mylib) mkBoolOpt;
+  cfg = config.shelken.wm.omniwm;
+
+  omniwmTomlPath = "${config.home.homeDirectory}/nix-config/home/darwin/wm/omniwm/settings.toml";
+in
+{
+  options.shelken.wm.omniwm = {
+    enable = mkBoolOpt false "Whether or not to enable omniwm.";
+  };
+
+  config = mkIf cfg.enable {
+    launchd.agents.omniwm = mylib.mkLaunchCommand {
+      name = "omniwm";
+      commandFile = "/Applications/OmniWM.app/Contents/MacOS/OmniWM";
+      domain = "gui";
+    };
+
+    xdg.configFile = {
+      "omniwm/settings.toml" = {
+        source = config.lib.file.mkOutOfStoreSymlink omniwmTomlPath;
+        force = true;
+      };
+    };
+  };
+}

--- a/home/darwin/wm/omniwm/settings.toml
+++ b/home/darwin/wm/omniwm/settings.toml
@@ -1,0 +1,1185 @@
+monitorBarOverrides = []
+monitorDwindleOverrides = []
+monitorGapOverrides = []
+monitorNiriOverrides = []
+monitorOrientationOverrides = []
+monitorRoutingOverrides = []
+schemaVersion = 1
+
+[appearance]
+mode = "dark"
+
+[borders]
+enabled = true
+width = 5.0
+
+[borders.color]
+alpha = 1.0
+blue = 0.979300037944676
+green = 1.0
+red = 0.08458520228437894
+
+[clipboard]
+historyEnabled = false
+maxItemBytes = 8388608
+maxItems = 200
+maxTotalBytes = 67108864
+
+[dwindle]
+defaultSplitRatio = 1.0
+moveToRootStable = true
+singleWindowFit = "fill"
+smartSplit = false
+splitWidthMultiplier = 1.0
+useGlobalGaps = true
+
+[focus]
+crossesMonitorAtEdge = false
+followsMouse = false
+followsWindowToMonitor = true
+lockModifier = "off"
+moveCrossesMonitorAtEdge = false
+moveMouseToFocusedWindow = false
+raiseOnMouseFocus = false
+
+[gaps]
+fullscreenUsesOuterGaps = false
+size = 4.0
+
+[gaps.outer]
+bottom = 4.0
+left = 4.0
+right = 4.0
+top = 4.0
+
+[general]
+animationsEnabled = true
+defaultLayoutType = "niri"
+hotkeysEnabled = true
+hyperKeyModifiers = "Control+Option+Shift+Command"
+ipcEnabled = false
+preventSleepEnabled = false
+systemHyperTrigger = "None"
+updateChecksEnabled = true
+
+[gestures]
+fingerCount = 3
+invertDirection = true
+mouseMoveModifierKey = "option"
+mouseResizeModifierKey = "option"
+scrollEnabled = true
+scrollModifierKey = "optionShift"
+scrollSensitivity = 5.0
+trackpadScrollStyle = "snap"
+workspaceSwipeAxis = "vertical"
+workspaceSwipeEnabled = false
+workspaceSwipeFingerCount = 3
+
+[hiddenBar]
+enabled = true
+hiddenBundleIDs = []
+rehideIntervalSeconds = 5.0
+
+[mouseWarp]
+constrainToArrangement = false
+enabled = true
+margin = 1
+
+[niri]
+alwaysCenterSingleColumn = false
+centerFocusedColumn = "never"
+containerPrimarySpanPresets = [0.3333333333333333, 0.5, 0.6666666666666666]
+defaultContainerPrimarySpan = 0.5
+infiniteLoop = false
+singleWindowFit = "fill"
+visibleContainerCount = 2
+
+[overview]
+zoom = 1.0
+
+[overview.backdrop]
+alpha = 1.0
+blue = 0.08
+green = 0.05
+red = 0.05
+
+[overview.windowBorders]
+
+[overview.windowBorders.hovered]
+alpha = 1.0
+blue = 1.0
+green = 0.6
+red = 0.4
+
+[overview.windowBorders.normal]
+alpha = 0.5
+blue = 0.35
+green = 0.3
+red = 0.3
+
+[overview.windowBorders.selected]
+alpha = 1.0
+blue = 0.4
+green = 0.8
+red = 0.3
+
+[quakeTerminal]
+animationDuration = 0.2
+autoHide = false
+backgroundBlurRadius = 0
+backgroundEffect = "standardBlur"
+enabled = true
+heightPercent = 50.0
+monitorMode = "focusedWindow"
+opacity = 1.0
+position = "center"
+widthPercent = 50.0
+
+[routing]
+mode = "macOS"
+
+[scratchpads]
+
+[scratchpads.labels]
+
+[statusBar]
+showAppNames = false
+showWorkspaceName = false
+useWorkspaceId = false
+
+[workspaceBar]
+backgroundOpacity = 0.1
+deduplicateAppIcons = false
+enabled = true
+excludedBundleIDs = []
+height = 24.0
+hideEmptyWorkspaces = false
+hideInNativeFullscreen = false
+notchActiveZoneWidth = 180.0
+notchMode = "moveBelowMenuBar"
+position = "overlappingMenuBar"
+reserveLayoutSpace = false
+revealHoldMilliseconds = 200.0
+revealModifier = "controlOption"
+showFloatingWindows = false
+showLabels = true
+systemStatsButton = false
+windowLevel = "popup"
+xOffset = 0.0
+yOffset = 0.0
+
+[workspaceBar.iconOverrides]
+
+[[appRules]]
+bundleId = "com.openai.codex"
+id = "6A31F08A-4051-4354-B439-42F4C71894A3"
+layout = "tile"
+assignToWorkspace = "2"
+minWidth = 800.0
+minHeight = 600.0
+
+[[appRules]]
+bundleId = "com.eltima.cmd1.pro.mas"
+id = "4BA546DA-2875-4BEF-B13F-1539E833B1A0"
+layout = "float"
+minWidth = 950.0
+minHeight = 550.0
+
+[[appRules]]
+bundleId = "com.google.Chrome"
+id = "486CEFA6-69AA-4A3C-AF27-BCD38F4F138B"
+layout = "tile"
+assignToWorkspace = "9"
+minWidth = 500.0
+minHeight = 375.0
+
+[[appRules]]
+bundleId = "dev.zed.Zed"
+id = "979F05F4-FFA2-4EDD-B23F-08A9944C759F"
+layout = "tile"
+assignToWorkspace = "2"
+minWidth = 360.0
+minHeight = 240.0
+
+[[appRules]]
+bundleId = "com.apple.Safari"
+id = "81426D13-C1A5-475E-AFBC-00BBA05042D0"
+layout = "tile"
+assignToWorkspace = "1"
+minWidth = 574.0
+minHeight = 220.0
+
+[[appRules]]
+bundleId = "app.zen-browser.zen"
+id = "1CF39647-F30D-4E76-9686-79B551F1B094"
+layout = "float"
+minWidth = 500.0
+minHeight = 495.0
+
+[[appRules]]
+bundleId = "org.mozilla.firefox"
+id = "005C00D3-F665-47F8-BDAE-D80790E9E46B"
+layout = "float"
+minWidth = 500.0
+minHeight = 120.0
+
+[[appRules]]
+bundleId = "company.thebrowser.dia"
+id = "C21156B1-0224-4998-97E3-8F4FA65B9F3B"
+layout = "float"
+minWidth = 500.0
+minHeight = 420.0
+
+[[appRules]]
+bundleId = "com.spotify.client"
+id = "2DE9390B-0DB4-4D0C-9ABA-06F76F1D4EA9"
+layout = "float"
+minWidth = 800.0
+minHeight = 600.0
+
+[[appRules]]
+bundleId = "com.hnc.Discord"
+id = "AF752D95-8497-4844-BE20-4C93E73BAEF2"
+layout = "float"
+minWidth = 800.0
+minHeight = 500.0
+
+[[appRules]]
+bundleId = "com.mitchellh.ghostty"
+id = "7876C9EF-437E-4D4F-9C27-B1B02F4AABCE"
+layout = "float"
+minWidth = 90.0
+minHeight = 48.0
+
+[[appRules]]
+bundleId = "com.microsoft.Outlook"
+id = "8ECAB78B-BCDD-4245-BC25-1609A49B1C86"
+layout = "float"
+minWidth = 930.0
+minHeight = 650.0
+
+[[appRules]]
+bundleId = "com.apple.MobileSMS"
+id = "552FB77D-BF0E-4737-90A6-B5BC6986C579"
+layout = "float"
+minWidth = 660.0
+minHeight = 320.0
+
+[[appRules]]
+bundleId = "net.imput.helium"
+id = "7E3A9A22-BFFE-5017-8840-3E8423721BDF"
+layout = "tile"
+assignToWorkspace = "1"
+
+[[appRules]]
+bundleId = "com.openai.atlas"
+id = "75BAF63D-AB79-53C9-8D85-F74EE2C3B0CC"
+layout = "tile"
+assignToWorkspace = "1"
+
+[[appRules]]
+bundleId = "com.jetbrains.intellij"
+id = "B847F8E3-1E9A-5526-9377-20150776E129"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "com.microsoft.VSCode"
+id = "4583C304-4712-58F6-97AA-9338E1F71576"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "dev.zed.Zed-Preview"
+id = "EB901EDA-BDC2-57F7-8397-C9C1DDA46667"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "com.yetone.alma"
+id = "886ACEE8-E4AF-5431-84E6-FEA66DEF5FEF"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "com.conductor.app"
+id = "D7BD53B2-D54B-5EE6-8A16-201EF3721B0D"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "com.todesktop.230313mzl4w4u92"
+id = "559A42BA-66FF-50F2-8705-86B837E1656C"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "com.muxy.app"
+id = "0CB7B644-A813-51FE-8A91-1D788D40EE5E"
+layout = "tile"
+assignToWorkspace = "2"
+
+[[appRules]]
+bundleId = "net.kovidgoyal.kitty"
+id = "F46232B2-05F5-542D-A5D5-903E878436B3"
+layout = "tile"
+assignToWorkspace = "3"
+
+[[appRules]]
+bundleId = "com.cmuxterm.app"
+id = "FD18AF09-ACA0-57FA-8246-18EE4133E53F"
+layout = "tile"
+assignToWorkspace = "3"
+
+[[appRules]]
+bundleId = "com.tencent.xinWeChat"
+id = "D632B0D6-1142-511D-B66F-C417B5FC9D5C"
+layout = "tile"
+assignToWorkspace = "5"
+
+[[appRules]]
+bundleId = "com.tencent.qq"
+id = "9CAEC60A-C440-55CF-B3CF-A000EA958395"
+layout = "tile"
+assignToWorkspace = "5"
+
+[[appRules]]
+bundleId = "ru.keepcoder.Telegram"
+id = "90EFE589-86F7-52F2-A09C-818A56AF8B2B"
+layout = "tile"
+assignToWorkspace = "5"
+
+[[appRules]]
+bundleId = "com.apple.Music"
+id = "2864ACA4-4722-5B21-836A-20B4C1DD81F4"
+layout = "tile"
+assignToWorkspace = "6"
+
+[[appRules]]
+bundleId = ""
+id = "86397E7A-E35D-51DF-B3F2-1346B5C13179"
+appNameSubstring = "NewsNow"
+layout = "tile"
+assignToWorkspace = "1"
+
+[[appRules]]
+bundleId = "com.apple.Terminal"
+id = "9B7E2300-C006-52BE-932B-2DE51F3AA52C"
+layout = "float"
+assignToWorkspace = "3"
+
+[[appRules]]
+bundleId = "md.obsidian"
+id = "44281419-C8CC-5CE1-9345-3DAD9C0A4ACA"
+layout = "float"
+assignToWorkspace = "4"
+
+[[appRules]]
+bundleId = "com.audirvana.Audirvana"
+id = "EDCCABA8-C79B-5B1D-B42E-778C3F252BED"
+layout = "float"
+assignToWorkspace = "6"
+
+[[appRules]]
+bundleId = "com.apple.finder"
+id = "65B83D9A-396F-5A74-B809-DCD5725142EA"
+layout = "float"
+assignToWorkspace = "8"
+
+[[appRules]]
+bundleId = "com.apple.Preview"
+id = "406FB169-8FA0-545C-9683-A623F59E0EBA"
+layout = "float"
+assignToWorkspace = "8"
+
+[[appRules]]
+bundleId = "com.apple.ScreenSharing"
+id = "62E47C02-10B3-578A-9AC9-CB40314F3D05"
+layout = "float"
+assignToWorkspace = "9"
+
+[[appRules]]
+bundleId = "tv.parsec.www"
+id = "4BF78868-C153-549A-A4E8-9136A7192B9D"
+layout = "float"
+assignToWorkspace = "9"
+
+[[appRules]]
+bundleId = "app.motrix.native"
+id = "BDFC83DD-3818-5486-97EA-45898F22B1A3"
+layout = "float"
+assignToWorkspace = "9"
+
+[[appRules]]
+bundleId = "com.now.gg.BlueStacks"
+id = "3FFB99B4-B77F-5491-8DC9-9AD894430ADA"
+layout = "float"
+assignToWorkspace = "9"
+
+[[appRules]]
+bundleId = "com.now.gg.BlueStacksMIM"
+id = "DA3BB564-E050-5378-B364-FDD94563EC72"
+layout = "float"
+assignToWorkspace = "9"
+
+[[appRules]]
+bundleId = ""
+id = "2A98523A-75A6-5291-97E7-A57F97BCA70F"
+layout = "float"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.1"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.1"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.2"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.2"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.3"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.3"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.4"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.4"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.5"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.5"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.6"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.6"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.7"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.7"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.8"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.8"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.9"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.9"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleScratchpad.10"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "assignFocusedWindowToScratchpad.10"
+
+[[hotkeys]]
+binding = "Option+1"
+id = "switchWorkspace.0"
+
+[[hotkeys]]
+binding = "Option+Shift+1"
+id = "moveToWorkspace.0"
+
+[[hotkeys]]
+binding = "Option+2"
+id = "switchWorkspace.1"
+
+[[hotkeys]]
+binding = "Option+Shift+2"
+id = "moveToWorkspace.1"
+
+[[hotkeys]]
+binding = "Option+3"
+id = "switchWorkspace.2"
+
+[[hotkeys]]
+binding = "Option+Shift+3"
+id = "moveToWorkspace.2"
+
+[[hotkeys]]
+binding = "Option+4"
+id = "switchWorkspace.3"
+
+[[hotkeys]]
+binding = "Option+Shift+4"
+id = "moveToWorkspace.3"
+
+[[hotkeys]]
+binding = "Option+5"
+id = "switchWorkspace.4"
+
+[[hotkeys]]
+binding = "Option+Shift+5"
+id = "moveToWorkspace.4"
+
+[[hotkeys]]
+binding = "Option+6"
+id = "switchWorkspace.5"
+
+[[hotkeys]]
+binding = "Option+Shift+6"
+id = "moveToWorkspace.5"
+
+[[hotkeys]]
+binding = "Option+7"
+id = "switchWorkspace.6"
+
+[[hotkeys]]
+binding = "Option+Shift+7"
+id = "moveToWorkspace.6"
+
+[[hotkeys]]
+binding = "Option+8"
+id = "switchWorkspace.7"
+
+[[hotkeys]]
+binding = "Option+Shift+8"
+id = "moveToWorkspace.7"
+
+[[hotkeys]]
+binding = "Option+9"
+id = "switchWorkspace.8"
+
+[[hotkeys]]
+binding = "Option+Shift+9"
+id = "moveToWorkspace.8"
+
+[[hotkeys]]
+binding = "Control+Option+Tab"
+id = "workspaceBackAndForth"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "switchWorkspace.next"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "switchWorkspace.previous"
+
+[[hotkeys]]
+binding = "Option+Left Arrow"
+id = "focus.left"
+
+[[hotkeys]]
+binding = "Option+Down Arrow"
+id = "focus.down"
+
+[[hotkeys]]
+binding = "Option+Up Arrow"
+id = "focus.up"
+
+[[hotkeys]]
+binding = "Option+Right Arrow"
+id = "focus.right"
+
+[[hotkeys]]
+binding = "Option+Tab"
+id = "focusPrevious"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusDownOrLeft"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusUpOrRight"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowTop"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowBottom"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowDownOrTop"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowUpOrBottom"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowOrWorkspaceDown"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowOrWorkspaceUp"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "centerColumn"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "centerVisibleColumns"
+
+[[hotkeys]]
+binding = "Control+Option+Shift+Up Arrow"
+id = "moveWindowToWorkspaceUp"
+
+[[hotkeys]]
+binding = "Control+Option+Shift+Down Arrow"
+id = "moveWindowToWorkspaceDown"
+
+[[hotkeys]]
+binding = "Control+Option+Shift+Page Up"
+id = "moveColumnToWorkspaceUp"
+
+[[hotkeys]]
+binding = "Control+Option+Shift+Page Down"
+id = "moveColumnToWorkspaceDown"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.0"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.1"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.2"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.3"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.4"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.5"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.6"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.7"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToWorkspace.8"
+
+[[hotkeys]]
+binding = "Option+Shift+Left Arrow"
+id = "move.left"
+
+[[hotkeys]]
+binding = "Option+Shift+Down Arrow"
+id = "move.down"
+
+[[hotkeys]]
+binding = "Option+Shift+Up Arrow"
+id = "move.up"
+
+[[hotkeys]]
+binding = "Option+Shift+Right Arrow"
+id = "move.right"
+
+[[hotkeys]]
+binding = "Control+Option+Down Arrow"
+id = "moveWindowDown"
+
+[[hotkeys]]
+binding = "Control+Option+Up Arrow"
+id = "moveWindowUp"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWindowDownOrToWorkspaceDown"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWindowUpOrToWorkspaceUp"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "consumeWindowIntoColumn"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "expelWindowFromColumn"
+
+[[hotkeys]]
+binding = "Control+Command+Tab"
+id = "focusMonitorNext"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusMonitorPrevious"
+
+[[hotkeys]]
+binding = "Control+Command+Grave"
+id = "focusMonitorLast"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWorkspaceToMonitor.left"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWorkspaceToMonitor.right"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWorkspaceToMonitor.up"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWorkspaceToMonitor.down"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWindowToMonitor.left"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWindowToMonitor.right"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWindowToMonitor.up"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveWindowToMonitor.down"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleFullscreen"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleNativeFullscreen"
+
+[[hotkeys]]
+binding = "Control+Option+Left Arrow"
+id = "moveColumn.left"
+
+[[hotkeys]]
+binding = "Control+Option+Right Arrow"
+id = "moveColumn.right"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumn.up"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumn.down"
+
+[[hotkeys]]
+binding = "Control+Option+Home"
+id = "moveColumnToFirst"
+
+[[hotkeys]]
+binding = "Control+Option+End"
+id = "moveColumnToLast"
+
+[[hotkeys]]
+binding = "Option+T"
+id = "toggleColumnTabbed"
+
+[[hotkeys]]
+binding = "Option+Home"
+id = "focusColumnFirst"
+
+[[hotkeys]]
+binding = "Option+End"
+id = "focusColumnLast"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.0"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.1"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.2"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.3"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.4"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.5"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.6"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.7"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusColumn.8"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.1"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.2"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.3"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.4"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.5"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.6"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.7"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.8"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "focusWindowInColumn.9"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.1"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.2"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.3"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.4"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.5"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.6"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.7"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.8"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveColumnToIndex.9"
+
+[[hotkeys]]
+binding = "Option+Period"
+id = "cycleSizeForward"
+
+[[hotkeys]]
+binding = "Option+Comma"
+id = "cycleSizeBackward"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "cycleWindowPrimarySpanForward"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "cycleWindowPrimarySpanBackward"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "cycleWindowSecondarySpanForward"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "cycleWindowSecondarySpanBackward"
+
+[[hotkeys]]
+binding = "Control+Option+Return"
+id = "toggleContainerFullPrimarySpan"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "expandContainerToAvailablePrimarySpan"
+
+[[hotkeys]]
+binding = "Control+Option+R"
+id = "resetWindowSecondarySpan"
+
+[[hotkeys]]
+binding = "Option+Minus"
+id = "setContainerPrimarySpan.decrease10Percent"
+
+[[hotkeys]]
+binding = "Option+Equal"
+id = "setContainerPrimarySpan.increase10Percent"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "setWindowPrimarySpan.decrease10Percent"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "setWindowPrimarySpan.increase10Percent"
+
+[[hotkeys]]
+binding = "Option+Shift+Minus"
+id = "setWindowSecondarySpan.decrease10Percent"
+
+[[hotkeys]]
+binding = "Option+Shift+Equal"
+id = "setWindowSecondarySpan.increase10Percent"
+
+[[hotkeys]]
+binding = "Option+Shift+B"
+id = "balanceSizes"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "moveToRoot"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleSplit"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "swapSplit"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "resizeGrow.horizontal"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "resizeGrow.vertical"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "resizeShrink.horizontal"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "resizeShrink.vertical"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "resizeFocusedWindow.grow"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "resizeFocusedWindow.shrink"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "preselect.left"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "preselect.right"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "preselect.up"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "preselect.down"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "preselectClear"
+
+[[hotkeys]]
+binding = "Control+Option+Space"
+id = "openCommandPalette"
+
+[[hotkeys]]
+binding = "Option+Shift+R"
+id = "raiseAllFloatingWindows"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "rescueOffscreenWindows"
+
+[[hotkeys]]
+binding = "Control+Option+F"
+id = "toggleFocusedWindowFloating"
+
+[[hotkeys]]
+binding = "Control+Option+M"
+id = "openMenuAnywhere"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleWorkspaceBarVisibility"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleHiddenBarPanel"
+
+[[hotkeys]]
+binding = "Option+Grave"
+id = "toggleQuakeTerminal"
+
+[[hotkeys]]
+binding = "Option+Slash"
+id = "toggleWorkspaceLayout"
+
+[[hotkeys]]
+binding = "Option+Shift+O"
+id = "toggleOverview"
+
+[[hotkeys]]
+binding = "Unassigned"
+id = "toggleSystemStats"
+
+[[workspaces]]
+displayName = "1Browser"
+id = "AD36F001-C57E-41A5-AC1D-DF5249D007F0"
+layoutType = "niri"
+name = "1"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "2Code"
+id = "454CECD4-5E9D-4ED1-95D7-979D48817F5F"
+layoutType = "niri"
+name = "2"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "3Terminal"
+id = "BEB842B5-E894-4791-9FD1-397C3CDD3538"
+layoutType = "niri"
+name = "3"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "4Write"
+id = "248AA883-2261-4D45-943C-79C0E46A232B"
+layoutType = "niri"
+name = "4"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "5Chat"
+id = "8B8C45D6-CE9E-41D9-BD50-BE4989D5E3DE"
+layoutType = "niri"
+name = "5"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "6Music"
+id = "5953F2BF-A378-4266-91B2-287174C4FA4D"
+layoutType = "niri"
+name = "6"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "7"
+id = "A7D5E104-6985-4516-8ED5-07F144F2A33D"
+layoutType = "niri"
+name = "7"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "8File"
+id = "A53347B7-C3CC-50C7-BF1C-529886422138"
+layoutType = "niri"
+name = "8"
+
+[workspaces.monitorAssignment]
+type = "main"
+
+[[workspaces]]
+displayName = "9Other"
+id = "86106C7F-B46B-5295-A57B-8FA2159C9897"
+layoutType = "niri"
+name = "9"
+
+[workspaces.monitorAssignment]
+type = "main"

--- a/hosts/mio/default.nix
+++ b/hosts/mio/default.nix
@@ -8,7 +8,8 @@ in
   system.defaults.smb.NetBIOSName = hostname;
   shelken = {
     # window manager
-    wm.aerospace.enable = true;
+    wm.aerospace.enable = false;
+    wm.omniwm.enable = true;
     tools.hammerspoon.enable = false;
     wm.thaw.enable = true;
 

--- a/hosts/mio/home.nix
+++ b/hosts/mio/home.nix
@@ -25,6 +25,7 @@
     # 与 darwin 侧（hosts/mio/default.nix）同名同值，两棵树互不相见需手动镜像
     tools.autoinputswitch.enable = true;
     tools.backup.enable = true;
-    wm.aerospace.enable = true;
+    wm.aerospace.enable = false;
+    wm.omniwm.enable = true;
   };
 }

--- a/modules/darwin/wm/default.nix
+++ b/modules/darwin/wm/default.nix
@@ -4,6 +4,7 @@
     ./skhd.nix
     ./yabai.nix
     ./aerospace.nix
+    ./omniwm.nix
     ./thaw.nix
     # ./sketchybar.nix
   ];

--- a/modules/darwin/wm/omniwm.nix
+++ b/modules/darwin/wm/omniwm.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  mylib,
+  config,
+  ...
+}:
+let
+  inherit (lib) mkIf;
+  inherit (mylib) mkBoolOpt;
+  cfg = config.shelken.wm.omniwm;
+in
+{
+  options.shelken.wm.omniwm = {
+    enable = mkBoolOpt false "Whether or not to enable omniwm.";
+  };
+
+  config = mkIf cfg.enable {
+    homebrew = {
+      taps = [
+        {
+          name = "BarutSRB/tap";
+          trusted = true;
+        }
+      ];
+      casks = [
+        "omniwm"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
## Why

在 mio 上渐进体验 OmniWM，同时保留 AeroSpace 配置，确保可以快速回退并继续对照两者行为。OmniWM 的 v1 配置要求完整 canonical schema，因此由 Home Manager 管理完整配置并通过 out-of-store symlink 保留实时编辑体验。

## Scope

- 新增 `modules/darwin/wm/omniwm.nix`，声明官方 Homebrew tap 与 cask
- 新增 `home/darwin/wm/omniwm.nix`，管理 canonical 配置链接与 GUI login agent
- 新增 9 个 Niri 工作区、应用路由、浮动规则和 AeroSpace 习惯快捷键
- 将 Workspace Bar 改为按住 `Control+Option` 临时显示
- 在 `hosts/mio/default.nix` 与 `hosts/mio/home.nix` 中停用 AeroSpace 并启用 OmniWM
- 保留全部 AeroSpace 模块和配置
- 暂不迁移 PIP hook、多显示器行为、Service 模式和外部命令快捷键

## Tradeoffs

OmniWM 不支持配置 include 或局部 override，仓库因此保存完整 v1 schema。配置使用稳定的主仓库路径作为 out-of-store symlink 目标，修改文件后可由 OmniWM 实时热重载，无需重新运行 Home Manager。

## Blast Radius

运行时行为仅影响 mio。其他主机继续使用 AeroSpace。OmniWM 模块默认关闭，不会改变未显式启用它的配置。

## Verification

- `nix build .#darwinConfigurations.mio.system --no-link --extra-experimental-features "nix-command flakes"` 通过
- `pre-commit run` 通过，包括 nixfmt、Prettier 和 typos
- canonical 配置审计通过，确认 169 个唯一 action、无重复快捷键、9 个主屏工作区和 40 条应用规则
- Home Manager activation package 包含 `settings.toml` out-of-store symlink 与 `space.ooooo.omniwm` GUI launchd agent
- 配置已在 mio 上实时加载，OmniWM 日志未报告配置或快捷键错误
