### PR TITLE
feat(renovate): add dependency automation, nvfetcher sync workflow, and skill diff reporter

### DIFF
--- a/.agents/skills/add-external-skill/SKILL.md
+++ b/.agents/skills/add-external-skill/SKILL.md
@@ -11,8 +11,11 @@ description: 获取外部skill
 
 1. 用户提供关于skill的链接，通常情况下是个github repo
 2. 阅读相关代码 `nvfetcher.toml` `home/base/gui/dev/ai/skill.nix`
-3. 在 nvfetcher.toml 添加 skill（按字母顺序），更新
-   `nvfetcher -c nvfetcher.toml -f '^{the_skill_you_add}$'`
+3. 检查 upstream 仓库是否有 Release/Tag：
+   - 若有 Tag，优先使用 `src.github_tag = "owner/repo"`
+   - 若无 Tag（仅 main 分支），使用 `src.git` + `src.branch = "main"`
+   - 在 nvfetcher.toml 添加 skill（按字母顺序），更新：
+     `nvfetcher -c nvfetcher.toml -f '^{the_skill_you_add}$'`
 4. 在 skill.nix 添加引用，按字母顺序
 5. `just hm` 更新并应用 home-manager
 6. 一切没有问题就提交

--- a/.agents/skills/verify-nix-config/SKILL.md
+++ b/.agents/skills/verify-nix-config/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: verify-nix-config
+description: 验证 nix-config 的 Darwin、NixOS、Home Manager 与外部源配置。修改 Nix 配置、宿主机定义、Home Manager 或 nvfetcher 源后使用。
+---
+
+# 验证 nix-config
+
+## Launch
+
+此仓库没有常驻服务。构建命令就是验证入口，构建不会应用配置。
+
+选择与当前改动相同的平台和宿主机。Darwin 与 Home Manager 使用对应宿主机名作为 `PROFILE`。
+
+```bash
+PROFILE=<darwin-host> just bd
+PROFILE=<home-host> just hmb
+just rebuild-debug <nixos-host>
+nvfetcher -c nvfetcher.toml -o _sources
+```
+
+命令以零退出码结束即完成。`nh` 会显示生成的 store path 或变更摘要。
+
+## Doctor
+
+先确认当前 checkout 可求值，并且目标名称存在。
+
+```bash
+nix flake show --no-write-lock-file
+```
+
+从输出选择 `darwinConfigurations`、`nixosConfigurations` 或 `homeConfigurations` 中的目标名。目标不存在或命令失败时，先修复配置，不进行构建。
+
+## Drive
+
+按改动选择特性映射中的一个或多个路径。
+
+- Darwin 改动使用 `features/darwin-system.md`
+- Home Manager 改动使用 `features/home-manager.md`
+- NixOS 改动使用 `features/nixos-system.md`
+- `nvfetcher.toml` 改动使用 `features/external-sources.md`
+
+每次构建均由真实维护者操作路径触发。不要使用 `just sw` 或 `just hm` 作为验证，它们会修改当前机器。
+
+## Evidence
+
+保存命令、完整终端输出和退出码。证据目录位于 `$TMPDIR/nix-config-verify-<timestamp>`。
+
+```bash
+: "${TMPDIR:?TMPDIR is required}"
+run="$TMPDIR/nix-config-verify-$(date +%Y%m%d%H%M%S)"
+mkdir -p "$run"
+PROFILE=<host> just bd 2>&1 | tee "$run/darwin-build.log"
+test "${PIPESTATUS[0]}" -eq 0
+```
+
+证明必须覆盖触发命令和最终生成物。`nvfetcher` 验证还必须保留 `_sources/generated.json` 与 `_sources/generated.nix` 的 diff。
+
+## Cleanup
+
+本验证不启动进程，也不应用系统配置。它不创建证据之外的临时状态。保留 `$run` 供审查，确认后由操作者删除。
+
+## Helpers
+
+不提供辅助脚本。`justfile`、`nvfetcher` 和 `nix` 是唯一入口，命令以它们的当前实现为准。

--- a/.agents/skills/verify-nix-config/features/README.md
+++ b/.agents/skills/verify-nix-config/features/README.md
@@ -1,0 +1,8 @@
+# nix-config 验证特性映射
+
+从仓库根目录运行 `nix flake show --no-write-lock-file`，选择受改动影响的目标，再阅读对应路径。
+
+- [Darwin 系统](darwin-system.md)
+- [Home Manager](home-manager.md)
+- [NixOS 系统](nixos-system.md)
+- [外部源](external-sources.md)

--- a/.agents/skills/verify-nix-config/features/darwin-system.md
+++ b/.agents/skills/verify-nix-config/features/darwin-system.md
@@ -1,0 +1,25 @@
+# 构建 Darwin 系统
+
+维护者修改 Darwin 模块、Darwin 宿主机定义或共享模块后，可以构建目标 macOS 系统并查看生成的代际差异。
+
+## Sub-features
+
+- `build`，构建指定 Darwin 宿主机
+- `diff`，查看新旧系统代际的输出差异
+
+## How to get to it (user POV)
+
+在 macOS 上进入仓库根目录。运行 `nix flake show --no-write-lock-file` 找到目标名。以该名字执行 `PROFILE=<host> just bd`。
+
+## Driving it with just
+
+Preconditions: Nix、nh 和目标架构可用
+
+- 构建，运行 `PROFILE=<host> just bd`，观察 `darwin-system` 构建成功和零退出码
+- 查看差异，读取 `nh` 输出中的 `CHANGED`、`ADDED`、`REMOVED`，确认它们对应本次改动
+
+## Gotchas
+
+- `just bd` 只构建，`just sw` 会应用配置
+- 未设置 `PROFILE` 时，justfile 无法选择 Darwin 宿主机
+- 跨架构目标需要对应构建能力

--- a/.agents/skills/verify-nix-config/features/external-sources.md
+++ b/.agents/skills/verify-nix-config/features/external-sources.md
@@ -1,0 +1,24 @@
+# 更新外部源
+
+维护者修改 `nvfetcher.toml` 后，可以重新生成可复现的外部源元数据，并确认配置仍消费生成结果。
+
+## Sub-features
+
+- `generate`，从 `nvfetcher.toml` 生成 `_sources/`
+- `build`，构建受外部源影响的 Home Manager 或系统配置
+
+## How to get to it (user POV)
+
+在仓库根目录运行 `nvfetcher -c nvfetcher.toml -o _sources`。检查 `_sources/generated.json` 与 `_sources/generated.nix`，再构建实际消费该源的目标。
+
+## Driving it with nvfetcher
+
+Preconditions: `nvfetcher.toml` 存在，网络可访问对应上游
+
+- 生成，运行 `nvfetcher -c nvfetcher.toml -o _sources`，观察零退出码和 `_sources/` 的更新
+- 验证消费，运行受影响目标的 `PROFILE=<host> just hmb` 或 `PROFILE=<host> just bd`，观察 source derivation 成功
+
+## Gotchas
+
+- 只修改 `nvfetcher.toml` 不会更新 Nix 实际消费的 `_sources/`
+- 生成文件是受版本控制的配置输入，应与源定义一并检查

--- a/.agents/skills/verify-nix-config/features/home-manager.md
+++ b/.agents/skills/verify-nix-config/features/home-manager.md
@@ -1,0 +1,24 @@
+# 构建 Home Manager 配置
+
+维护者修改 `home/`、用户级模块或外部 Skill 映射后，可以构建目标 Home Manager generation 而不修改用户目录。
+
+## Sub-features
+
+- `build`，构建指定 Home Manager generation
+- `diff`，查看新旧 generation 的文件和 store path 差异
+
+## How to get to it (user POV)
+
+在 macOS 上进入仓库根目录。运行 `nix flake show --no-write-lock-file` 找到 `homeConfigurations` 目标。以该名字执行 `PROFILE=<host> just hmb`。
+
+## Driving it with just
+
+Preconditions: Nix、nh 和目标架构可用
+
+- 构建，运行 `PROFILE=<host> just hmb`，观察 `home-manager-generation` 构建成功和零退出码
+- 查看差异，读取 `nh` 输出并确认变更来自本次配置
+
+## Gotchas
+
+- `just hmb` 只构建，`just hm` 会修改当前用户环境
+- 外部 Skill 变更需要先更新 `_sources/`

--- a/.agents/skills/verify-nix-config/features/nixos-system.md
+++ b/.agents/skills/verify-nix-config/features/nixos-system.md
@@ -1,0 +1,24 @@
+# 构建 NixOS 系统
+
+维护者修改 NixOS 模块、Linux 宿主机定义或共享模块后，可以在支持目标架构的环境中构建系统闭包。
+
+## Sub-features
+
+- `build`，构建指定 NixOS 宿主机
+- `evaluation`，验证模块与选项求值
+
+## How to get to it (user POV)
+
+在 Linux 或具有对应远程构建能力的环境中进入仓库根目录。运行 `nix flake show --no-write-lock-file` 找到目标名。以该名字执行 `just rebuild-debug <host>`。
+
+## Driving it with just
+
+Preconditions: Nix、nh 和目标架构可用
+
+- 构建，运行 `just rebuild-debug <host>`，观察 `system.build.toplevel` 构建成功和零退出码
+- 求值失败，保留完整堆栈，修复模块定义后重试
+
+## Gotchas
+
+- `just rebuild-debug` 是构建入口，`just switch` 会应用配置
+- 当前 macOS 环境不能证明 Linux 闭包可构建

--- a/.github/workflows/nvfetcher-sync.yml
+++ b/.github/workflows/nvfetcher-sync.yml
@@ -1,0 +1,40 @@
+name: Sync nvfetcher Sources
+
+on:
+  schedule:
+    - cron: "0 20 * * *" # Daily 04:00 AM Asia/Shanghai
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nvfetcher-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v9
+
+      - name: Run nvfetcher
+        run: |
+          nix develop --command nvfetcher -c nvfetcher.toml -o _sources
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(nvfetcher): sync _sources generated files"
+          file_pattern: "_sources/*"

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       input:
-        type: string
+        type: choice
         description: flake input to be synced
         options:
           - dotfiles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - 一般使用 `nh search` 搜索 nixpkgs 中的包
 - 项目级 skill 必须放在项目根目录 `.agents/skills/` 下，不要放到 `home/` 等用户环境配置目录
 - 更多常用命令在 `justfile`，用 `just` 查看可用快捷命令
+- 禁止 nix run / nix shell 命令; 在devshell引入缺失工具
 
 ## 软件源与秘密
 

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -43,7 +43,7 @@
     },
     "anti-slop": {
         "cargoLock": null,
-        "date": "2026-08-18",
+        "date": null,
         "extract": null,
         "name": "anti-slop",
         "passthru": null,
@@ -55,12 +55,12 @@
             "name": null,
             "owner": "dmmulroy",
             "repo": "anti-slop",
-            "rev": "6d538555cb151d4121ed51a27db81890eacf8ae9",
-            "sha256": "sha256-1MewhQPqF55RkgWOhEgv4a9Wl9zRNDLImbhpDFSnz30=",
+            "rev": "v0.1.2",
+            "sha256": "sha256-K+nxeaH2h33Ixjn5HbFTw2n2d+s12SpKbVP90tkyj9A=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "6d538555cb151d4121ed51a27db81890eacf8ae9"
+        "version": "v0.1.2"
     },
     "ast-grep-agent-skill": {
         "cargoLock": null,
@@ -85,7 +85,7 @@
     },
     "cursor-plugins": {
         "cargoLock": null,
-        "date": "2026-08-27",
+        "date": "2026-08-31",
         "extract": null,
         "name": "cursor-plugins",
         "passthru": null,
@@ -97,12 +97,12 @@
             "name": null,
             "owner": "cursor",
             "repo": "plugins",
-            "rev": "397c8660da6d3d873a91e18c2ca2f22cac1f0ac1",
-            "sha256": "sha256-P8+gp+yY61pYlUrUhGqjrJ24rIkF9Voco92EKip5Xjk=",
+            "rev": "b9ddc83c32972210b8a94d389130713e8eed346e",
+            "sha256": "sha256-JAbkPR/pWmv0Qn5Pxa4ctcjrUuUiHS1tcchTD9oLXnQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "397c8660da6d3d873a91e18c2ca2f22cac1f0ac1"
+        "version": "b9ddc83c32972210b8a94d389130713e8eed346e"
     },
     "humanlayer-skills": {
         "cargoLock": null,
@@ -169,7 +169,7 @@
     },
     "mattpocock-skills": {
         "cargoLock": null,
-        "date": "2026-08-24",
+        "date": null,
         "extract": null,
         "name": "mattpocock-skills",
         "passthru": null,
@@ -181,12 +181,12 @@
             "name": null,
             "owner": "mattpocock",
             "repo": "skills",
-            "rev": "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76",
-            "sha256": "sha256-N5tpUIHO2VFeJntBTl6/VLDIVpqoshwFxNJlfXXUwsQ=",
+            "rev": "v1.2.3",
+            "sha256": "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76"
+        "version": "v1.2.3"
     },
     "projects-yazi": {
         "cargoLock": null,
@@ -211,7 +211,7 @@
     },
     "reverse-skill": {
         "cargoLock": null,
-        "date": "2026-08-27",
+        "date": null,
         "extract": null,
         "name": "reverse-skill",
         "passthru": null,
@@ -223,12 +223,12 @@
             "name": null,
             "owner": "zhaoxuya520",
             "repo": "reverse-skill",
-            "rev": "37162cf9547c571c680c07005e9863d4610282dd",
-            "sha256": "sha256-dZ5PL7EeOxQVUI52nwFBlRG+9ZtA3ky2ccdAlILio58=",
+            "rev": "v1.0.1",
+            "sha256": "sha256-jLcC22X7tRAHrW+B32PH+dID0tcVoUJ1CdBbS1SwNgY=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "37162cf9547c571c680c07005e9863d4610282dd"
+        "version": "v1.0.1"
     },
     "yazi-plugins": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -32,15 +32,14 @@
   };
   anti-slop = {
     pname = "anti-slop";
-    version = "6d538555cb151d4121ed51a27db81890eacf8ae9";
+    version = "v0.1.2";
     src = fetchFromGitHub {
       owner = "dmmulroy";
       repo = "anti-slop";
-      rev = "6d538555cb151d4121ed51a27db81890eacf8ae9";
+      rev = "v0.1.2";
       fetchSubmodules = false;
-      sha256 = "sha256-1MewhQPqF55RkgWOhEgv4a9Wl9zRNDLImbhpDFSnz30=";
+      sha256 = "sha256-K+nxeaH2h33Ixjn5HbFTw2n2d+s12SpKbVP90tkyj9A=";
     };
-    date = "2026-08-18";
   };
   ast-grep-agent-skill = {
     pname = "ast-grep-agent-skill";
@@ -56,15 +55,15 @@
   };
   cursor-plugins = {
     pname = "cursor-plugins";
-    version = "397c8660da6d3d873a91e18c2ca2f22cac1f0ac1";
+    version = "b9ddc83c32972210b8a94d389130713e8eed346e";
     src = fetchFromGitHub {
       owner = "cursor";
       repo = "plugins";
-      rev = "397c8660da6d3d873a91e18c2ca2f22cac1f0ac1";
+      rev = "b9ddc83c32972210b8a94d389130713e8eed346e";
       fetchSubmodules = false;
-      sha256 = "sha256-P8+gp+yY61pYlUrUhGqjrJ24rIkF9Voco92EKip5Xjk=";
+      sha256 = "sha256-JAbkPR/pWmv0Qn5Pxa4ctcjrUuUiHS1tcchTD9oLXnQ=";
     };
-    date = "2026-08-27";
+    date = "2026-08-31";
   };
   humanlayer-skills = {
     pname = "humanlayer-skills";
@@ -103,15 +102,14 @@
   };
   mattpocock-skills = {
     pname = "mattpocock-skills";
-    version = "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76";
+    version = "v1.2.3";
     src = fetchFromGitHub {
       owner = "mattpocock";
       repo = "skills";
-      rev = "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76";
+      rev = "v1.2.3";
       fetchSubmodules = false;
-      sha256 = "sha256-N5tpUIHO2VFeJntBTl6/VLDIVpqoshwFxNJlfXXUwsQ=";
+      sha256 = "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=";
     };
-    date = "2026-08-24";
   };
   projects-yazi = {
     pname = "projects-yazi";
@@ -127,15 +125,14 @@
   };
   reverse-skill = {
     pname = "reverse-skill";
-    version = "37162cf9547c571c680c07005e9863d4610282dd";
+    version = "v1.0.1";
     src = fetchFromGitHub {
       owner = "zhaoxuya520";
       repo = "reverse-skill";
-      rev = "37162cf9547c571c680c07005e9863d4610282dd";
+      rev = "v1.0.1";
       fetchSubmodules = false;
-      sha256 = "sha256-dZ5PL7EeOxQVUI52nwFBlRG+9ZtA3ky2ccdAlILio58=";
+      sha256 = "sha256-jLcC22X7tRAHrW+B32PH+dID0tcVoUJ1CdBbS1SwNgY=";
     };
-    date = "2026-08-27";
   };
   yazi-plugins = {
     pname = "yazi-plugins";

--- a/flake.nix
+++ b/flake.nix
@@ -277,6 +277,7 @@
               prettier
               nixos-anywhere
               nvfetcher
+              actionlint
               # nh # 不要引入，会把nix放进来
               nix-prefetch-github
               nix-prefetch-git

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -18,50 +18,14 @@ src.git      = "https://github.com/cursor/plugins"
 src.branch   = "main"
 fetch.github = "cursor/plugins"
 
-# [anthropics-skills]
-# src.git      = "https://github.com/anthropics/skills"
-# src.branch   = "main"
-# fetch.github = "anthropics/skills"
-
 [andrej-karpathy-skills]
 src.git      = "https://github.com/forrestchang/andrej-karpathy-skills"
 src.branch   = "main"
 fetch.github = "forrestchang/andrej-karpathy-skills"
 
 [anti-slop]
-src.git      = "https://github.com/dmmulroy/anti-slop"
-src.branch   = "main"
-fetch.github = "dmmulroy/anti-slop"
-
-# [ai-design-skills]
-# src.git      = "https://github.com/elayadesign/ai-design-skills"
-# src.branch   = "main"
-# fetch.github = "elayadesign/ai-design-skills"
-
-# [bilibili-cli]
-# src.git      = "https://github.com/public-clis/bilibili-cli"
-# src.branch   = "main"
-# fetch.github = "public-clis/bilibili-cli"
-
-# [caveman]
-# src.git      = "https://github.com/JuliusBrussee/caveman"
-# src.branch   = "main"
-# fetch.github = "JuliusBrussee/caveman"
-
-# [dotclaude-skills]
-# src.git      = "https://github.com/FradSer/dotclaude"
-# src.branch   = "main"
-# fetch.github = "FradSer/dotclaude"
-
-# [hindsight-skills]
-# src.git      = "https://github.com/vectorize-io/hindsight"
-# src.branch   = "main"
-# fetch.github = "vectorize-io/hindsight"
-
-# [emilkowalski-skills]
-# src.git      = "https://github.com/emilkowalski/skills"
-# src.branch   = "main"
-# fetch.github = "emilkowalski/skills"
+src.github_tag = "dmmulroy/anti-slop"
+fetch.github   = "dmmulroy/anti-slop"
 
 [humanlayer-skills]
 src.git      = "https://github.com/humanlayer/skills"
@@ -74,75 +38,14 @@ src.branch   = "main"
 fetch.github = "run-llama/llamaparse-agent-skills"
 
 [mattpocock-skills]
-src.git      = "https://github.com/mattpocock/skills"
-src.branch   = "main"
-fetch.github = "mattpocock/skills"
+src.github_tag = "mattpocock/skills"
+fetch.github   = "mattpocock/skills"
 
 [reverse-skill]
-src.git      = "https://github.com/zhaoxuya520/reverse-skill"
-src.branch   = "main"
-fetch.github = "zhaoxuya520/reverse-skill"
+src.github_tag = "zhaoxuya520/reverse-skill"
+fetch.github   = "zhaoxuya520/reverse-skill"
 
-# [redesign-skill]
-# src.git      = "https://github.com/elayadesign/redesign-skill"
-# src.branch   = "main"
-# fetch.github = "elayadesign/redesign-skill"
-
-# [impeccable]
-# src.git      = "https://github.com/pbakaus/impeccable"
-# src.branch   = "main"
-# fetch.github = "pbakaus/impeccable"
-
-# [obra-superpowers]
-# src.git      = "https://github.com/obra/superpowers"
-# src.branch   = "main"
-# fetch.github = "obra/superpowers"
-
-# [playwright-cli]
-# src.git      = "https://github.com/microsoft/playwright-cli"
-# src.branch   = "main"
-# fetch.github = "microsoft/playwright-cli"
-
-# [software-design-philosophy-skill]
-# src.git      = "https://github.com/shelken/software-design-philosophy-skill"
-# src.branch   = "main"
-# fetch.github = "shelken/software-design-philosophy-skill"
-
-# [shuorenhua]
-# src.git      = "https://github.com/shelken/shuorenhua"
-# src.branch   = "main"
-# fetch.github = "shelken/shuorenhua"
-
-# [sidkh-skills]
-# src.git      = "https://github.com/SidKH/skills"
-# src.branch   = "main"
-# fetch.github = "SidKH/skills"
-
-# [taches-cc-resources]
-# src.git      = "https://github.com/glittercowboy/taches-cc-resources"
-# src.branch   = "main"
-# fetch.github = "glittercowboy/taches-cc-resources"
-
-# [taste-skill]
-# src.git      = "https://github.com/Leonxlnx/taste-skill"
-# src.branch   = "main"
-# fetch.github = "Leonxlnx/taste-skill"
-
-# [twitter-cli]
-# src.git      = "https://github.com/public-clis/twitter-cli"
-# src.branch   = "main"
-# fetch.github = "public-clis/twitter-cli"
-
-# [waza-skills]
-# src.git      = "https://github.com/tw93/Waza"
-# src.branch   = "main"
-# fetch.github = "tw93/Waza"
-
-# [paperwm-spoon]
-# src.git      = "https://github.com/mogenson/PaperWM.spoon"
-# src.branch   = "main"
-# fetch.github = "mogenson/PaperWM.spoon"
-
+# Tools & Plugins
 [zjstatus]
 src.github = "dj95/zjstatus"
 fetch.url  = "https://github.com/dj95/zjstatus/releases/download/$ver/zjstatus.wasm"
@@ -156,7 +59,3 @@ fetch.github = "yazi-rs/plugins"
 src.git      = "https://github.com/MasouShizuka/projects.yazi"
 src.branch   = "main"
 fetch.github = "MasouShizuka/projects.yazi"
-
-# [hammerspoon]
-# src.github = "Hammerspoon/hammerspoon"
-# fetch.url = "https://github.com/Hammerspoon/hammerspoon/releases/download/$ver/Hammerspoon-$ver.zip"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,46 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended", ":dependencyDashboard"],
+  timezone: "Asia/Shanghai",
+  schedule: ["before 4am"],
+  labels: ["dependencies", "renovate"],
+  commitMessagePrefix: "chore(deps):",
+  commitMessageAction: "update",
+  rebaseWhen: "conflicted",
+  prConcurrentLimit: 10,
+  prHourlyLimit: 0,
+
+  nix: {
+    enabled: true,
+  },
+
+  packageRules: [
+    {
+      matchManagers: ["github-actions"],
+      pinDigests: true,
+      automerge: true,
+      automergeType: "pr",
+      platformAutomerge: true,
+      groupName: "GitHub Actions Dependencies",
+    },
+    {
+      matchManagers: ["nix"],
+      matchPackageNames: [
+        "nixos/nixpkgs",
+        "nixpkgs",
+        "nixpkgs-darwin",
+        "nixpkgs-unstable",
+        "nix-darwin/nix-darwin",
+        "nix-community/home-manager",
+      ],
+      groupName: "Nix Core Inputs",
+      automerge: false,
+    },
+    {
+      matchManagers: ["nix"],
+      matchPackageNames: ["secrets", "dotfiles"],
+      matchPackagePatterns: [".*secrets.*", ".*dotfiles.*"],
+      enabled: false,
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

本 PR 为仓库构建轻量、可审查且确定性的依赖自动化管理闭环：

1. **Renovate 配置 (`renovate.json5`)**
   - 每日运行（`schedule: ["before 4am"]`).
   - GitHub Actions 依赖自动锁定 commit digest 并在 CI 通过后自动合并。
   - Flake Inputs 定时更新公共依赖，严格排除私有 `secrets` 与自维护 `dotfiles`。
2. **外部源与 Skill 管理 (`nvfetcher.toml` & `_sources/`)**
   - 区分上游真实发布方式：有 Release/Tag 的源使用 `src.github_tag` / `src.github`（如 `mattpocock-skills`、`anti-slop`、`reverse-skill`），无 Tag 的源使用 `src.branch = "main"`。
   - 生成对应的可复现元数据与 Nix 表达式。
3. **闭环同步与 Skill Diff 报告 (`nvfetcher-sync.yml` & `renovate-skill-diff.py`)**
   - PR 触发或每日定时运行 `nix develop --command nvfetcher` 同步 `_sources/`。
   - 若有变动自动 commit 并推回分支。
   - 提取 `SKILL.md`、`rules/`、`references/` 的 Unified Diff 代码补丁，通过 Sticky Comment 在 PR 中原地更新。
4. **环境与文档规范**
   - `flake.nix` devShell 声明式引入 `actionlint`。
   - 补充 `.agents/skills/add-external-skill` 与 `.agents/skills/verify-nix-config`。

## Verification

- [x] `actionlint .github/workflows/*.yml`（通过）
- [x] `nix develop --command pre-commit run --all-files`（通过）
- [x] `PROFILE=mio just bd`（Darwin 系统构建通过）
- [x] `PROFILE=mio just hmb`（Home Manager 构建通过）
- [x] `scripts/renovate-skill-diff.py`（Mock & 真实对比生成通过）