### PR TITLE
fix(ci): create PRs for nvfetcher updates

### DIFF
--- a/.github/workflows/nvfetcher-sync.yml
+++ b/.github/workflows/nvfetcher-sync.yml
@@ -7,9 +7,10 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-main
   cancel-in-progress: true
 
 jobs:
@@ -17,24 +18,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.ref_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          ref: main
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v16
-
-      - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Run nvfetcher
         run: |
           nix develop --command nvfetcher -c nvfetcher.toml -o _sources
 
-      - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          commit_message: "chore(nvfetcher): sync _sources generated files"
-          file_pattern: "_sources/*"
+          add-paths: |
+            _sources/generated.json
+            _sources/generated.nix
+          branch: automation/nvfetcher-sync
+          base: main
+          delete-branch: true
+          commit-message: "chore(nvfetcher): sync _sources generated files"
+          title: "chore(nvfetcher): sync _sources generated files"
+          body: "Automated synchronization of nvfetcher sources."

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended", ":dependencyDashboard"],
+  enabledManagers: ["github-actions", "nix"],
   timezone: "Asia/Shanghai",
   schedule: ["before 4am"],
   labels: ["dependencies", "renovate"],
@@ -38,8 +39,7 @@
     },
     {
       matchManagers: ["nix"],
-      matchPackageNames: ["secrets", "dotfiles"],
-      matchPackagePatterns: [".*secrets.*", ".*dotfiles.*"],
+      matchDepNames: ["secrets", "dotfiles", "herdr"],
       enabled: false,
     },
   ],


### PR DESCRIPTION
## 修正内容

- nvfetcher 同步只在 `automation/nvfetcher-sync` 创建或更新待审 PR，不再写入 `main`。
- 删除已弃用且导致失败缓存、长尾执行时间的 Magic Nix Cache。
- 将 workflow 依赖升级并固定到 Node 24 运行时的完整 SHA。
- 限制 Renovate 只管理 GitHub Actions 和 Nix inputs，并按 flake input 名排除 `secrets`、`dotfiles`、`herdr`。

## 验证

- `actionlint .github/workflows/nvfetcher-sync.yml`
- `prettier --check .github/workflows/nvfetcher-sync.yml renovate.json5`
- `pre-commit run --files .github/workflows/nvfetcher-sync.yml renovate.json5`

Co-Authored-By: gpt-5.6-terra
