### PR TITLE
fix(ci): restore nvfetcher PR sticky diff comment

### DIFF
--- a/.github/workflows/nvfetcher-sync.yml
+++ b/.github/workflows/nvfetcher-sync.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -25,6 +26,9 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
+      - name: Save source baseline
+        run: cp _sources/generated.json /tmp/nvfetcher-base.json
+
       - name: Run nvfetcher
         run: |
           nix develop --command nvfetcher -c nvfetcher.toml -o _sources
@@ -41,3 +45,24 @@ jobs:
           commit-message: "chore(nvfetcher): sync _sources generated files"
           title: "chore(nvfetcher): sync _sources generated files"
           body: "Automated synchronization of nvfetcher sources."
+
+      - name: Find automation pull request
+        id: automation_pull_request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "number=$(gh pr list \
+            --base main \
+            --head automation/nvfetcher-sync \
+            --json number \
+            --jq '.[0].number // empty')" >> "$GITHUB_OUTPUT"
+
+      - name: Update source diff comment
+        if: steps.automation_pull_request.outputs.number != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/renovate-skill-diff.py \
+            --base-file /tmp/nvfetcher-base.json \
+            --head-file _sources/generated.json \
+            --pull-request "${{ steps.automation_pull_request.outputs.number }}"

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -148,7 +148,7 @@
     },
     "llamaparse-agent-skills": {
         "cargoLock": null,
-        "date": "2026-07-03",
+        "date": null,
         "extract": null,
         "name": "llamaparse-agent-skills",
         "passthru": null,
@@ -160,12 +160,12 @@
             "name": null,
             "owner": "run-llama",
             "repo": "llamaparse-agent-skills",
-            "rev": "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0",
-            "sha256": "sha256-KzYcArVClk1mUBYLM/EmU3+rKzAHtpHRLAFVY1LbtKQ=",
+            "rev": "liteparse-1.0.1",
+            "sha256": "sha256-BGZyNJXJ1Yt/k4jm+CEwRwqcTSBAb+pG7yGxqoK35tI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0"
+        "version": "liteparse-1.0.1"
     },
     "mattpocock-skills": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -90,15 +90,14 @@
   };
   llamaparse-agent-skills = {
     pname = "llamaparse-agent-skills";
-    version = "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0";
+    version = "liteparse-1.0.1";
     src = fetchFromGitHub {
       owner = "run-llama";
       repo = "llamaparse-agent-skills";
-      rev = "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0";
+      rev = "liteparse-1.0.1";
       fetchSubmodules = false;
-      sha256 = "sha256-KzYcArVClk1mUBYLM/EmU3+rKzAHtpHRLAFVY1LbtKQ=";
+      sha256 = "sha256-BGZyNJXJ1Yt/k4jm+CEwRwqcTSBAb+pG7yGxqoK35tI=";
     };
-    date = "2026-07-03";
   };
   mattpocock-skills = {
     pname = "mattpocock-skills";

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -33,9 +33,9 @@ src.branch   = "main"
 fetch.github = "humanlayer/skills"
 
 [llamaparse-agent-skills]
-src.git      = "https://github.com/run-llama/llamaparse-agent-skills"
-src.branch   = "main"
-fetch.github = "run-llama/llamaparse-agent-skills"
+src.github_tag    = "run-llama/llamaparse-agent-skills"
+src.include_regex = "liteparse-.*"
+fetch.github      = "run-llama/llamaparse-agent-skills"
 
 [mattpocock-skills]
 src.github_tag = "mattpocock/skills"

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,7 @@
     },
     {
       matchManagers: ["nix"],
-      matchPackageNames: [
+      matchDepNames: [
         "nixos/nixpkgs",
         "nixpkgs",
         "nixpkgs-darwin",

--- a/scripts/renovate-skill-diff.py
+++ b/scripts/renovate-skill-diff.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+MARKER = "<!-- nvfetcher-skill-diff -->"
+RELEVANT_PATH_PARTS = ("SKILL.md", "skills/", "references/", "rules/")
+MAX_PATCH_LINES = 300
+MAX_PATCH_CHARS = 12000
+MAX_REPORT_CHARS = 64000
+
+
+def read_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as file:
+        return json.load(file)
+
+
+def source_repository(item: dict) -> tuple[str, str] | None:
+    source = item["src"]
+    owner = source.get("owner")
+    repo = source.get("repo")
+    if owner and repo:
+        return owner, repo
+    url = source.get("url")
+    if not url:
+        return None
+    parts = urllib.parse.urlparse(url).path.strip("/").split("/")
+    if len(parts) < 2 or parts[0] == "":
+        return None
+    return parts[0], parts[1].removesuffix(".git")
+
+
+def source_revision(item: dict) -> str:
+    return item["src"].get("rev", item["version"])
+
+
+def github_json(
+    method: str,
+    url: str,
+    payload: dict | None = None,
+    token: str | None = None,
+) -> dict | list:
+    data = None if payload is None else json.dumps(payload).encode()
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "nvfetcher-skill-diff",
+    }
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def compare_files(owner: str, repo: str, base: str, head: str, token: str | None) -> list[dict]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}"
+    response = github_json("GET", url, token=token)
+    return response["files"]
+
+
+def relevant_file(filename: str) -> bool:
+    return any(part in filename for part in RELEVANT_PATH_PARTS)
+
+
+def format_patch(file: dict) -> str:
+    patch = file.get("patch", "")
+    blob_url = file.get("blob_url", "")
+    if not patch:
+        return f"_Diff unavailable. [Open file]({blob_url})_\n" if blob_url else "_Diff unavailable._\n"
+    lines = patch.splitlines()
+    if len(lines) > MAX_PATCH_LINES or len(patch) > MAX_PATCH_CHARS:
+        patch = "\n".join(lines[:MAX_PATCH_LINES])
+        suffix = f" [Open full file]({blob_url})" if blob_url else ""
+        return f"```diff\n{patch}\n```\n\n_Diff truncated.{suffix}_\n"
+    return f"```diff\n{patch}\n```\n"
+
+
+def generate_report(base_data: dict, head_data: dict, fetch_compare) -> str:
+    sections: list[str] = [MARKER, "## 📦 External Sources & Skills Diff Report"]
+    for name in sorted(set(base_data) | set(head_data)):
+        before = base_data.get(name)
+        after = head_data.get(name)
+        if before == after:
+            continue
+        if before is None:
+            sections.append(f"### `{name}` added at `{after['version']}`")
+            continue
+        if after is None:
+            sections.append(f"### `{name}` removed from `{before['version']}`")
+            continue
+        old_version = before["version"]
+        new_version = after["version"]
+        sections.append(f"### `{name}`: `{old_version}` → `{new_version}`")
+        repository = source_repository(after) or source_repository(before)
+        old_revision = source_revision(before)
+        new_revision = source_revision(after)
+        if repository is None or old_revision == new_revision:
+            continue
+        owner, repo = repository
+        sections.append(
+            f"🔗 [Full GitHub Comparison](https://github.com/{owner}/{repo}/compare/{old_revision}...{new_revision})"
+        )
+        files = fetch_compare(owner, repo, old_revision, new_revision)
+        relevant_files = [file for file in files if relevant_file(file["filename"])]
+        if not relevant_files:
+            sections.append("_No changes in `SKILL.md`, `skills/`, `references/`, or `rules/`._")
+            continue
+        sections.append("#### 📝 Detailed Skill & Rule Diffs")
+        for file in relevant_files:
+            sections.append(
+                f"<details><summary><b><code>{file['filename']}</code></b> ({file['status']}, +{file['additions']}, -{file['deletions']})</summary>\n"
+                f"{format_patch(file)}</details>"
+            )
+    report = "\n\n".join(sections)
+    if report == "\n\n".join(sections[:2]):
+        return ""
+    if len(report) <= MAX_REPORT_CHARS:
+        return report
+    return report[: MAX_REPORT_CHARS - len("\n\n_Report truncated._")] + "\n\n_Report truncated._"
+
+
+def sync_comment(repository: str, pull_request: str, body: str, request) -> str:
+    for page in range(1, 101):
+        comments = request(
+            "GET",
+            f"/repos/{repository}/issues/{pull_request}/comments?per_page=100&page={page}",
+            None,
+        )
+        for comment in comments:
+            if comment["user"]["login"] == "github-actions[bot]" and MARKER in comment["body"]:
+                request("PATCH", f"/repos/{repository}/issues/comments/{comment['id']}", {"body": body})
+                return "updated"
+        if len(comments) < 100:
+            break
+    request("POST", f"/repos/{repository}/issues/{pull_request}/comments", {"body": body})
+    return "created"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-file", required=True)
+    parser.add_argument("--head-file", required=True)
+    parser.add_argument("--pull-request", required=True)
+    args = parser.parse_args()
+
+    token = os.environ["GITHUB_TOKEN"]
+    repository = os.environ["GITHUB_REPOSITORY"]
+    report = generate_report(
+        read_json(args.base_file),
+        read_json(args.head_file),
+        lambda owner, repo, base, head: compare_files(owner, repo, base, head, token),
+    )
+    if not report:
+        return
+
+    def request(method: str, path: str, payload: dict | None) -> dict | list:
+        return github_json(method, f"https://api.github.com{path}", payload, token)
+
+    print(sync_comment(repository, args.pull_request, report, request))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_renovate_skill_diff.py
+++ b/scripts/tests/test_renovate_skill_diff.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location('renovate_skill_diff', Path('scripts/renovate-skill-diff.py'))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+report = module.generate_report(
+    {
+        'demo-skill': {
+            'version': 'v1.0.0',
+            'src': {'owner': 'example', 'repo': 'demo-skill', 'rev': 'v1.0.0'},
+        },
+    },
+    {
+        'demo-skill': {
+            'version': 'v1.1.0',
+            'src': {'owner': 'example', 'repo': 'demo-skill', 'rev': 'v1.1.0'},
+        },
+    },
+    lambda owner, repo, base, head: [{
+        'filename': 'skills/demo/SKILL.md',
+        'status': 'modified',
+        'additions': 1,
+        'deletions': 1,
+        'patch': '@@ -1 +1 @@\n-old\n+new',
+        'blob_url': 'https://example.test/SKILL.md',
+    }],
+)
+assert module.MARKER in report
+assert '`demo-skill`: `v1.0.0` → `v1.1.0`' in report
+assert 'https://github.com/example/demo-skill/compare/v1.0.0...v1.1.0' in report
+assert 'skills/demo/SKILL.md' in report
+
+requests = []
+def request(method, path, payload):
+    requests.append((method, path, payload))
+    if method == 'GET':
+        return []
+    return {}
+
+assert module.sync_comment('owner/repo', '42', report, request) == 'created'
+assert requests[-1] == ('POST', '/repos/owner/repo/issues/42/comments', {'body': report})
+
+requests = []
+def request(method, path, payload):
+    requests.append((method, path, payload))
+    if path.endswith('page=1'):
+        return [{'id': index, 'user': {'login': 'someone'}, 'body': 'other'} for index in range(100)]
+    if path.endswith('page=2'):
+        return [{'id': 9, 'user': {'login': 'github-actions[bot]'}, 'body': module.MARKER}]
+    return {}
+
+assert module.sync_comment('owner/repo', '42', report, request) == 'updated'
+assert requests[0] == ('GET', '/repos/owner/repo/issues/42/comments?per_page=100&page=1', None)
+assert requests[1] == ('GET', '/repos/owner/repo/issues/42/comments?per_page=100&page=2', None)
+assert requests[-1] == ('PATCH', '/repos/owner/repo/issues/comments/9', {'body': report})


### PR DESCRIPTION
## 修正内容

- 恢复 `scripts/renovate-skill-diff.py`：生成外部源版本变化、上游 compare 链接和 `SKILL.md`/`rules/`/`references/` 实际 diff 的报告
- nvfetcher-sync 工作流在创建/更新 automation PR 后，同步唯一带标记的 sticky comment（创建或 PATCH 更新，不产生重复评论）
- `llamaparse-agent-skills` 改为按 `liteparse-*` tag 轨道跟踪（本仓库实际只导入 `skills/liteparse`），`_sources/` 已重新生成为 `liteparse-1.0.1`
- Renovate 核心输入分组修正为 `matchDepNames`（官方 Nix manager 语义：depName 即 flake input 名）

## 验证

- `python3 scripts/tests/test_renovate_skill_diff.py`
- `python3 -m py_compile scripts/renovate-skill-diff.py`
- 用 PR #40 前后的真实 `_sources/generated.json` 生成完整报告，内容与 PR #40 原评论一致
- `actionlint` / `prettier --check` / `pre-commit run --all-files`

Co-Authored-By: gpt-5.6-terra
