### PR TITLE
fix(ci): create one nvfetcher PR per source

### DIFF
--- a/.github/workflows/nvfetcher-sync.yml
+++ b/.github/workflows/nvfetcher-sync.yml
@@ -15,7 +15,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  nvfetcher-sync:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      sources: ${{ steps.changed_sources.outputs.sources }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Discover changed sources
+        id: changed_sources
+        run: |
+          cp _sources/generated.json /tmp/nvfetcher-base.json
+          nix develop --command nvfetcher -c nvfetcher.toml -o _sources
+          python3 - <<'PY'
+          import json
+          import os
+
+          with open("/tmp/nvfetcher-base.json", encoding="utf-8") as file:
+              base = json.load(file)
+          with open("_sources/generated.json", encoding="utf-8") as file:
+              head = json.load(file)
+          changed = sorted(name for name in set(base) | set(head) if base.get(name) != head.get(name))
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(f"sources={json.dumps(changed, separators=(',', ':'))}", file=output)
+          PY
+
+  update:
+    needs: discover
+    if: needs.discover.outputs.sources != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ${{ fromJSON(needs.discover.outputs.sources) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -26,44 +63,58 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - name: Save source baseline
-        run: cp _sources/generated.json /tmp/nvfetcher-base.json
-
-      - name: Run nvfetcher
+      - name: Update source
+        env:
+          SOURCE: ${{ matrix.source }}
         run: |
-          nix develop --command nvfetcher -c nvfetcher.toml -o _sources
+          cp _sources/generated.json /tmp/nvfetcher-base.json
+          nix develop --command nvfetcher -c nvfetcher.toml -f "^${SOURCE}$" -o _sources
           cp _sources/generated.json /tmp/nvfetcher-head.json
 
       - name: Create pull request
+        id: create_pull_request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: |
             _sources/generated.json
             _sources/generated.nix
-          branch: automation/nvfetcher-sync
+          branch: automation/nvfetcher/${{ matrix.source }}
           base: main
           delete-branch: true
-          commit-message: "chore(nvfetcher): sync _sources generated files"
-          title: "chore(nvfetcher): sync _sources generated files"
-          body: "Automated synchronization of nvfetcher sources."
-
-      - name: Find automation pull request
-        id: automation_pull_request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "number=$(gh pr list \
-            --base main \
-            --head automation/nvfetcher-sync \
-            --json number \
-            --jq '.[0].number // empty')" >> "$GITHUB_OUTPUT"
+          commit-message: "chore(nvfetcher): update ${{ matrix.source }}"
+          title: "chore(nvfetcher): update ${{ matrix.source }}"
+          body: "Automated update of `${{ matrix.source }}` managed by nvfetcher."
 
       - name: Update source diff comment
-        if: steps.automation_pull_request.outputs.number != ''
+        if: steps.create_pull_request.outputs.pull-request-number != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/renovate-skill-diff.py \
             --base-file /tmp/nvfetcher-base.json \
             --head-file /tmp/nvfetcher-head.json \
-            --pull-request "${{ steps.automation_pull_request.outputs.number }}"
+            --source "${{ matrix.source }}" \
+            --pull-request "${{ steps.create_pull_request.outputs.pull-request-number }}"
+
+  cleanup:
+    needs: [discover, update]
+    if: always() && needs.discover.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close obsolete source pull requests
+        env:
+          CHANGED_SOURCES: ${{ needs.discover.outputs.sources }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr list \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --state open \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("automation/nvfetcher/")) | [.number, .headRefName] | @tsv' |
+          while IFS=$'\t' read -r number branch; do
+            source="${branch#automation/nvfetcher/}"
+            if ! jq -e --arg source "$source" 'index($source) != null' <<< "$CHANGED_SOURCES" >/dev/null; then
+              gh pr close "$number" --repo "${{ github.repository }}" --delete-branch
+            fi
+          done

--- a/scripts/renovate-skill-diff.py
+++ b/scripts/renovate-skill-diff.py
@@ -2,16 +2,14 @@
 import argparse
 import json
 import os
-import urllib.error
 import urllib.parse
 import urllib.request
 
 MARKER = "<!-- nvfetcher-skill-diff -->"
 RELEVANT_PATH_PARTS = ("SKILL.md", "skills/", "references/", "rules/")
-MAX_PATCH_LINES = 35
-MAX_PATCH_CHARS = 1400
-MAX_FILES_PER_SOURCE = 6
-MAX_REPORT_CHARS = 60000
+MAX_PATCH_LINES = 300
+MAX_PATCH_CHARS = 12000
+MAX_REPORT_CHARS = 64000
 
 
 def read_json(path: str) -> dict:
@@ -60,11 +58,10 @@ def github_json(
 
 def compare_files(owner: str, repo: str, base: str, head: str, token: str | None) -> list[dict]:
     url = f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}"
-    try:
-        response = github_json("GET", url, token=token)
-        return response.get("files", []) if isinstance(response, dict) else []
-    except urllib.error.URLError:
-        return []
+    response = github_json("GET", url, token=token)
+    if not isinstance(response, dict):
+        raise TypeError("GitHub compare response must be an object")
+    return response["files"]
 
 
 def relevant_file(filename: str) -> bool:
@@ -78,64 +75,64 @@ def format_patch(file: dict) -> str:
         return f"_Diff unavailable. [Open file]({blob_url})_\n" if blob_url else "_Diff unavailable._\n"
     lines = patch.splitlines()
     if len(lines) > MAX_PATCH_LINES or len(patch) > MAX_PATCH_CHARS:
-        truncated_patch = "\n".join(lines[:MAX_PATCH_LINES])
+        patch = "\n".join(lines[:MAX_PATCH_LINES])
         suffix = f" [Open full file]({blob_url})" if blob_url else ""
-        return f"```diff\n{truncated_patch}\n```\n\n_Diff truncated.{suffix}_\n"
+        return f"```diff\n{patch}\n```\n\n_Diff truncated.{suffix}_\n"
     return f"```diff\n{patch}\n```\n"
 
 
-def generate_report(base_data: dict, head_data: dict, fetch_compare) -> str:
-    sections: list[str] = [MARKER, "## 📦 External Sources & Skills Diff Report"]
-    changed_names = sorted(set(base_data) | set(head_data))
-    for name in changed_names:
-        before = base_data.get(name)
-        after = head_data.get(name)
-        if before == after:
-            continue
-        if before is None:
-            sections.append(f"### `{name}` added at `{after['version']}`")
-            continue
-        if after is None:
-            sections.append(f"### `{name}` removed from `{before['version']}`")
-            continue
-        old_version = before.get("version", "")
-        new_version = after.get("version", "")
-        sections.append(f"### `{name}`: `{old_version}` → `{new_version}`")
-        repository = source_repository(after) or source_repository(before)
-        old_revision = source_revision(before)
-        new_revision = source_revision(after)
-        if repository is None or old_revision == new_revision or not old_revision or not new_revision:
-            continue
-        owner, repo = repository
-        sections.append(
-            f"🔗 [Full GitHub Comparison](https://github.com/{owner}/{repo}/compare/{old_revision}...{new_revision})"
-        )
-        files = fetch_compare(owner, repo, old_revision, new_revision)
-        relevant_files = [file for file in files if relevant_file(file.get("filename", ""))]
-        if not relevant_files:
-            sections.append("_No changes in `SKILL.md`, `skills/`, `references/`, or `rules/`._")
-            continue
-        sections.append("#### 📝 Detailed Skill & Rule Diffs")
-        shown_files = relevant_files[:MAX_FILES_PER_SOURCE]
-        for file in shown_files:
-            filename = file.get("filename", "unknown")
-            status = file.get("status", "modified")
-            additions = file.get("additions", 0)
-            deletions = file.get("deletions", 0)
-            sections.append(
-                f"<details><summary><b><code>{filename}</code></b> ({status}, +{additions}, -{deletions})</summary>\n"
-                f"{format_patch(file)}</details>"
-            )
-        if len(relevant_files) > len(shown_files):
-            overflow = len(relevant_files) - len(shown_files)
-            sections.append(f"_... and {overflow} more modified skill/rule files._")
-
-    report = "\n\n".join(sections)
-    if report == "\n\n".join(sections[:2]):
+def generate_report(base_data: dict, head_data: dict, source: str, fetch_compare) -> str:
+    before = base_data.get(source)
+    after = head_data.get(source)
+    if before == after:
         return ""
-    if len(report) <= MAX_REPORT_CHARS:
-        return report
-    return report[: MAX_REPORT_CHARS - len("\n\n_Report truncated._")] + "\n\n_Report truncated._"
+
+    sections = [MARKER, "## 📦 External Source & Skill Diff Report"]
+    if before is None:
+        sections.append(f"### `{source}` added at `{after['version']}`")
+        return "\n\n".join(sections)
+    if after is None:
+        sections.append(f"### `{source}` removed from `{before['version']}`")
+        return "\n\n".join(sections)
+
+    old_version = before.get("version", "")
+    new_version = after.get("version", "")
+    sections.append(f"### `{source}`: `{old_version}` → `{new_version}`")
+    repository = source_repository(after) or source_repository(before)
+    old_revision = source_revision(before)
+    new_revision = source_revision(after)
+    if repository is None or old_revision == new_revision or not old_revision or not new_revision:
+        return "\n\n".join(sections)
+
+    owner, repo = repository
+    sections.append(
+        f"🔗 [Full GitHub Comparison](https://github.com/{owner}/{repo}/compare/{old_revision}...{new_revision})"
+    )
+    files = fetch_compare(owner, repo, old_revision, new_revision)
+    relevant_files = [file for file in files if relevant_file(file.get("filename", ""))]
+    if not relevant_files:
+        sections.append("_No changes in `SKILL.md`, `skills/`, `references/`, or `rules/`._")
+        return "\n\n".join(sections)
+
+    sections.append("#### 📝 Detailed Skill & Rule Diffs")
+    omitted = 0
+    for index, file in enumerate(relevant_files):
+        filename = file.get("filename", "unknown")
+        status = file.get("status", "modified")
+        additions = file.get("additions", 0)
+        deletions = file.get("deletions", 0)
+        section = (
+            f"<details><summary><b><code>{filename}</code></b> ({status}, +{additions}, -{deletions})</summary>\n"
+            f"{format_patch(file)}</details>"
+        )
+        projected = "\n\n".join([*sections, section])
+        if len(projected) > MAX_REPORT_CHARS - 200:
+            omitted = len(relevant_files) - index
+            break
+        sections.append(section)
+    if omitted:
+        sections.append(f"_{omitted} additional skill/rule file diffs omitted. Use the comparison link above._")
+    return "\n\n".join(sections)
 
 
 def sync_comment(repository: str, pull_request: str, body: str, request) -> str:
@@ -159,6 +156,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-file", required=True)
     parser.add_argument("--head-file", required=True)
+    parser.add_argument("--source", required=True)
     parser.add_argument("--pull-request", required=True)
     args = parser.parse_args()
 
@@ -167,6 +165,7 @@ def main() -> None:
     report = generate_report(
         read_json(args.base_file),
         read_json(args.head_file),
+        args.source,
         lambda owner, repo, base, head: compare_files(owner, repo, base, head, token),
     )
     if not report:

--- a/scripts/tests/test_renovate_skill_diff.py
+++ b/scripts/tests/test_renovate_skill_diff.py
@@ -1,57 +1,78 @@
 import importlib.util
 from pathlib import Path
 
-spec = importlib.util.spec_from_file_location('renovate_skill_diff', Path('scripts/renovate-skill-diff.py'))
+spec = importlib.util.spec_from_file_location("renovate_skill_diff", Path("scripts/renovate-skill-diff.py"))
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
+base = {
+    "demo-skill": {
+        "version": "v1.0.0",
+        "src": {"owner": "example", "repo": "demo-skill", "rev": "v1.0.0"},
+    },
+    "other-skill": {
+        "version": "v2.0.0",
+        "src": {"owner": "example", "repo": "other-skill", "rev": "v2.0.0"},
+    },
+}
+head = {
+    "demo-skill": {
+        "version": "v1.1.0",
+        "src": {"owner": "example", "repo": "demo-skill", "rev": "v1.1.0"},
+    },
+    "other-skill": {
+        "version": "v2.1.0",
+        "src": {"owner": "example", "repo": "other-skill", "rev": "v2.1.0"},
+    },
+}
 report = module.generate_report(
-    {
-        'demo-skill': {
-            'version': 'v1.0.0',
-            'src': {'owner': 'example', 'repo': 'demo-skill', 'rev': 'v1.0.0'},
-        },
-    },
-    {
-        'demo-skill': {
-            'version': 'v1.1.0',
-            'src': {'owner': 'example', 'repo': 'demo-skill', 'rev': 'v1.1.0'},
-        },
-    },
-    lambda owner, repo, base, head: [{
-        'filename': 'skills/demo/SKILL.md',
-        'status': 'modified',
-        'additions': 1,
-        'deletions': 1,
-        'patch': '@@ -1 +1 @@\n-old\n+new',
-        'blob_url': 'https://example.test/SKILL.md',
-    }],
+    base,
+    head,
+    "demo-skill",
+    lambda owner, repo, old, new: [
+        {
+            "filename": "skills/demo/SKILL.md",
+            "status": "modified",
+            "additions": 1,
+            "deletions": 1,
+            "patch": "@@ -1 +1 @@\n-old\n+new",
+            "blob_url": "https://example.test/SKILL.md",
+        }
+    ],
 )
 assert module.MARKER in report
-assert '`demo-skill`: `v1.0.0` → `v1.1.0`' in report
-assert 'https://github.com/example/demo-skill/compare/v1.0.0...v1.1.0' in report
-assert 'skills/demo/SKILL.md' in report
+assert "`demo-skill`: `v1.0.0` → `v1.1.0`" in report
+assert "https://github.com/example/demo-skill/compare/v1.0.0...v1.1.0" in report
+assert "skills/demo/SKILL.md" in report
+assert "other-skill" not in report
+assert module.generate_report(base, base, "demo-skill", lambda *_: []) == ""
 
 requests = []
+
+
 def request(method, path, payload):
     requests.append((method, path, payload))
-    if method == 'GET':
+    if method == "GET":
         return []
     return {}
 
-assert module.sync_comment('owner/repo', '42', report, request) == 'created'
-assert requests[-1] == ('POST', '/repos/owner/repo/issues/42/comments', {'body': report})
+
+assert module.sync_comment("owner/repo", "42", report, request) == "created"
+assert requests[-1] == ("POST", "/repos/owner/repo/issues/42/comments", {"body": report})
 
 requests = []
+
+
 def request(method, path, payload):
     requests.append((method, path, payload))
-    if path.endswith('page=1'):
-        return [{'id': index, 'user': {'login': 'someone'}, 'body': 'other'} for index in range(100)]
-    if path.endswith('page=2'):
-        return [{'id': 9, 'user': {'login': 'github-actions[bot]'}, 'body': module.MARKER}]
+    if path.endswith("page=1"):
+        return [{"id": index, "user": {"login": "someone"}, "body": "other"} for index in range(100)]
+    if path.endswith("page=2"):
+        return [{"id": 9, "user": {"login": "github-actions[bot]"}, "body": module.MARKER}]
     return {}
 
-assert module.sync_comment('owner/repo', '42', report, request) == 'updated'
-assert requests[0] == ('GET', '/repos/owner/repo/issues/42/comments?per_page=100&page=1', None)
-assert requests[1] == ('GET', '/repos/owner/repo/issues/42/comments?per_page=100&page=2', None)
-assert requests[-1] == ('PATCH', '/repos/owner/repo/issues/comments/9', {'body': report})
+
+assert module.sync_comment("owner/repo", "42", report, request) == "updated"
+assert requests[0] == ("GET", "/repos/owner/repo/issues/42/comments?per_page=100&page=1", None)
+assert requests[1] == ("GET", "/repos/owner/repo/issues/42/comments?per_page=100&page=2", None)
+assert requests[-1] == ("PATCH", "/repos/owner/repo/issues/comments/9", {"body": report})


### PR DESCRIPTION
## 修正内容

- discovery job 只负责发现真实变化的 source。
- 每个 source 使用独立 matrix job、`automation/nvfetcher/<source>` 分支、PR 和 sticky comment。
- 评论脚本必须接收 `--source`，即使同次 discovery 有多个变化，也只报告当前 PR 的 source。
- cleanup job 关闭不再有差异的旧 source PR。
- GitHub compare API 失败时让 Action 失败，不发布与实际变更不完整的评论。

## 验证

- `nvfetcher -f '^cursor-plugins$'` 只修改 `cursor-plugins`。
- 评论测试同时传入两个变化 source，报告断言不包含另一个 source。
- `python3 scripts/tests/test_renovate_skill_diff.py`
- `python3 -m py_compile scripts/renovate-skill-diff.py scripts/tests/test_renovate_skill_diff.py`
- `actionlint .github/workflows/nvfetcher-sync.yml`
- `prettier --check .github/workflows/nvfetcher-sync.yml renovate.json5`

Co-Authored-By: gpt-5.6-terra
