### PR TITLE
fix(sources): remove nvfetcher-action-e2e-one test source

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -188,27 +188,6 @@
         },
         "version": "v1.2.3"
     },
-    "nvfetcher-action-e2e-one": {
-        "cargoLock": null,
-        "date": null,
-        "extract": null,
-        "name": "nvfetcher-action-e2e-one",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "deepClone": false,
-            "fetchSubmodules": false,
-            "leaveDotGit": false,
-            "name": null,
-            "owner": "DinkDonk",
-            "repo": "kitty-icon",
-            "rev": "v1.1.0",
-            "sha256": "sha256-q5wNdFRMvQDx3DlO7zdy/xPJbqcNlm4iVKaBwjxlSMs=",
-            "sparseCheckout": [],
-            "type": "github"
-        },
-        "version": "v1.1.0"
-    },
     "nvfetcher-action-e2e-two": {
         "cargoLock": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -111,17 +111,6 @@
       sha256 = "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=";
     };
   };
-  nvfetcher-action-e2e-one = {
-    pname = "nvfetcher-action-e2e-one";
-    version = "v1.1.0";
-    src = fetchFromGitHub {
-      owner = "DinkDonk";
-      repo = "kitty-icon";
-      rev = "v1.1.0";
-      fetchSubmodules = false;
-      sha256 = "sha256-q5wNdFRMvQDx3DlO7zdy/xPJbqcNlm4iVKaBwjxlSMs=";
-    };
-  };
   nvfetcher-action-e2e-two = {
     pname = "nvfetcher-action-e2e-two";
     version = "v1.2.3";


### PR DESCRIPTION
## 修正内容

删除端到端测试误写入正式 `_sources/generated.json` 和 `_sources/generated.nix` 的 `nvfetcher-action-e2e-one` 条目。

该 PR 只改变一个 source。

## 验证

相对 `main` 的生成源差异列表严格等于 `["nvfetcher-action-e2e-one"]`。

Co-Authored-By: gpt-5.6-terra
