### PR TITLE
fix(sources): remove nvfetcher-action-e2e-two test source

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -209,27 +209,6 @@
         },
         "version": "v1.1.0"
     },
-    "nvfetcher-action-e2e-two": {
-        "cargoLock": null,
-        "date": null,
-        "extract": null,
-        "name": "nvfetcher-action-e2e-two",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "deepClone": false,
-            "fetchSubmodules": false,
-            "leaveDotGit": false,
-            "name": null,
-            "owner": "mattpocock",
-            "repo": "skills",
-            "rev": "v1.2.3",
-            "sha256": "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=",
-            "sparseCheckout": [],
-            "type": "github"
-        },
-        "version": "v1.2.3"
-    },
     "projects-yazi": {
         "cargoLock": null,
         "date": "2026-07-11",

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -122,17 +122,6 @@
       sha256 = "sha256-q5wNdFRMvQDx3DlO7zdy/xPJbqcNlm4iVKaBwjxlSMs=";
     };
   };
-  nvfetcher-action-e2e-two = {
-    pname = "nvfetcher-action-e2e-two";
-    version = "v1.2.3";
-    src = fetchFromGitHub {
-      owner = "mattpocock";
-      repo = "skills";
-      rev = "v1.2.3";
-      fetchSubmodules = false;
-      sha256 = "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=";
-    };
-  };
   projects-yazi = {
     pname = "projects-yazi";
     version = "22a4006f531b7c8e71704f64e48feed659164104";


### PR DESCRIPTION
## 修正内容

删除端到端测试误写入正式 `_sources/generated.json` 和 `_sources/generated.nix` 的 `nvfetcher-action-e2e-two` 条目。

该 PR 只改变一个 source。

## 验证

相对 `main` 的生成源差异列表严格等于 `["nvfetcher-action-e2e-two"]`。

Co-Authored-By: gpt-5.6-terra
