### PR TITLE
fix(sources): restore liteparse release source

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -148,7 +148,7 @@
     },
     "llamaparse-agent-skills": {
         "cargoLock": null,
-        "date": "2026-07-03",
+        "date": null,
         "extract": null,
         "name": "llamaparse-agent-skills",
         "passthru": null,
@@ -160,12 +160,12 @@
             "name": null,
             "owner": "run-llama",
             "repo": "llamaparse-agent-skills",
-            "rev": "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0",
-            "sha256": "sha256-KzYcArVClk1mUBYLM/EmU3+rKzAHtpHRLAFVY1LbtKQ=",
+            "rev": "liteparse-1.0.1",
+            "sha256": "sha256-BGZyNJXJ1Yt/k4jm+CEwRwqcTSBAb+pG7yGxqoK35tI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0"
+        "version": "liteparse-1.0.1"
     },
     "mattpocock-skills": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -90,15 +90,14 @@
   };
   llamaparse-agent-skills = {
     pname = "llamaparse-agent-skills";
-    version = "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0";
+    version = "liteparse-1.0.1";
     src = fetchFromGitHub {
       owner = "run-llama";
       repo = "llamaparse-agent-skills";
-      rev = "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0";
+      rev = "liteparse-1.0.1";
       fetchSubmodules = false;
-      sha256 = "sha256-KzYcArVClk1mUBYLM/EmU3+rKzAHtpHRLAFVY1LbtKQ=";
+      sha256 = "sha256-BGZyNJXJ1Yt/k4jm+CEwRwqcTSBAb+pG7yGxqoK35tI=";
     };
-    date = "2026-07-03";
   };
   mattpocock-skills = {
     pname = "mattpocock-skills";


### PR DESCRIPTION
## 修正内容

只将 `llamaparse-agent-skills` 从误写入的滚动 commit 恢复为 `liteparse-1.0.1` Release。

本仓库实际只导入 `skills/liteparse`，`nvfetcher.toml` 已使用 `src.include_regex = "liteparse-.*"`。

## 验证

相对 `main` 的生成源差异列表严格等于 `["llamaparse-agent-skills"]`。

Co-Authored-By: gpt-5.6-terra
