### PR TITLE
refactor(ci): native per-source nvfetcher PR flow

### DIFF
--- a/.github/workflows/nvfetcher-sync.yml
+++ b/.github/workflows/nvfetcher-sync.yml
@@ -29,5 +29,6 @@ jobs:
 
       - name: Sync sources
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: nix develop --command python3 scripts/sync-sources.py

--- a/.github/workflows/nvfetcher-sync.yml
+++ b/.github/workflows/nvfetcher-sync.yml
@@ -1,0 +1,33 @@
+name: Sync nvfetcher Sources
+
+on:
+  schedule:
+    - cron: "0 20 * * *" # 每日 04:00 Asia/Shanghai
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-main
+  cancel-in-progress: true
+
+jobs:
+  nvfetcher-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Sync sources
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: nix develop --command python3 scripts/sync-sources.py

--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -43,7 +43,7 @@
     },
     "anti-slop": {
         "cargoLock": null,
-        "date": "2026-08-18",
+        "date": null,
         "extract": null,
         "name": "anti-slop",
         "passthru": null,
@@ -55,12 +55,12 @@
             "name": null,
             "owner": "dmmulroy",
             "repo": "anti-slop",
-            "rev": "6d538555cb151d4121ed51a27db81890eacf8ae9",
-            "sha256": "sha256-1MewhQPqF55RkgWOhEgv4a9Wl9zRNDLImbhpDFSnz30=",
+            "rev": "v0.1.2",
+            "sha256": "sha256-K+nxeaH2h33Ixjn5HbFTw2n2d+s12SpKbVP90tkyj9A=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "6d538555cb151d4121ed51a27db81890eacf8ae9"
+        "version": "v0.1.2"
     },
     "ast-grep-agent-skill": {
         "cargoLock": null,
@@ -148,7 +148,7 @@
     },
     "llamaparse-agent-skills": {
         "cargoLock": null,
-        "date": "2026-07-03",
+        "date": null,
         "extract": null,
         "name": "llamaparse-agent-skills",
         "passthru": null,
@@ -160,16 +160,16 @@
             "name": null,
             "owner": "run-llama",
             "repo": "llamaparse-agent-skills",
-            "rev": "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0",
-            "sha256": "sha256-KzYcArVClk1mUBYLM/EmU3+rKzAHtpHRLAFVY1LbtKQ=",
+            "rev": "liteparse-1.0.1",
+            "sha256": "sha256-BGZyNJXJ1Yt/k4jm+CEwRwqcTSBAb+pG7yGxqoK35tI=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0"
+        "version": "liteparse-1.0.1"
     },
     "mattpocock-skills": {
         "cargoLock": null,
-        "date": "2026-08-24",
+        "date": null,
         "extract": null,
         "name": "mattpocock-skills",
         "passthru": null,
@@ -181,12 +181,12 @@
             "name": null,
             "owner": "mattpocock",
             "repo": "skills",
-            "rev": "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76",
-            "sha256": "sha256-N5tpUIHO2VFeJntBTl6/VLDIVpqoshwFxNJlfXXUwsQ=",
+            "rev": "v1.2.3",
+            "sha256": "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76"
+        "version": "v1.2.3"
     },
     "projects-yazi": {
         "cargoLock": null,
@@ -211,7 +211,7 @@
     },
     "reverse-skill": {
         "cargoLock": null,
-        "date": "2026-08-27",
+        "date": null,
         "extract": null,
         "name": "reverse-skill",
         "passthru": null,
@@ -223,12 +223,12 @@
             "name": null,
             "owner": "zhaoxuya520",
             "repo": "reverse-skill",
-            "rev": "37162cf9547c571c680c07005e9863d4610282dd",
-            "sha256": "sha256-dZ5PL7EeOxQVUI52nwFBlRG+9ZtA3ky2ccdAlILio58=",
+            "rev": "v1.0.1",
+            "sha256": "sha256-jLcC22X7tRAHrW+B32PH+dID0tcVoUJ1CdBbS1SwNgY=",
             "sparseCheckout": [],
             "type": "github"
         },
-        "version": "37162cf9547c571c680c07005e9863d4610282dd"
+        "version": "v1.0.1"
     },
     "yazi-plugins": {
         "cargoLock": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -32,15 +32,14 @@
   };
   anti-slop = {
     pname = "anti-slop";
-    version = "6d538555cb151d4121ed51a27db81890eacf8ae9";
+    version = "v0.1.2";
     src = fetchFromGitHub {
       owner = "dmmulroy";
       repo = "anti-slop";
-      rev = "6d538555cb151d4121ed51a27db81890eacf8ae9";
+      rev = "v0.1.2";
       fetchSubmodules = false;
-      sha256 = "sha256-1MewhQPqF55RkgWOhEgv4a9Wl9zRNDLImbhpDFSnz30=";
+      sha256 = "sha256-K+nxeaH2h33Ixjn5HbFTw2n2d+s12SpKbVP90tkyj9A=";
     };
-    date = "2026-08-18";
   };
   ast-grep-agent-skill = {
     pname = "ast-grep-agent-skill";
@@ -91,27 +90,25 @@
   };
   llamaparse-agent-skills = {
     pname = "llamaparse-agent-skills";
-    version = "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0";
+    version = "liteparse-1.0.1";
     src = fetchFromGitHub {
       owner = "run-llama";
       repo = "llamaparse-agent-skills";
-      rev = "2dcef7c62417bd2ec4671fce4621bb1e8cce48d0";
+      rev = "liteparse-1.0.1";
       fetchSubmodules = false;
-      sha256 = "sha256-KzYcArVClk1mUBYLM/EmU3+rKzAHtpHRLAFVY1LbtKQ=";
+      sha256 = "sha256-BGZyNJXJ1Yt/k4jm+CEwRwqcTSBAb+pG7yGxqoK35tI=";
     };
-    date = "2026-07-03";
   };
   mattpocock-skills = {
     pname = "mattpocock-skills";
-    version = "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76";
+    version = "v1.2.3";
     src = fetchFromGitHub {
       owner = "mattpocock";
       repo = "skills";
-      rev = "6654f6b60cd9d5be8b54c6fafe44346dabeb3b76";
+      rev = "v1.2.3";
       fetchSubmodules = false;
-      sha256 = "sha256-N5tpUIHO2VFeJntBTl6/VLDIVpqoshwFxNJlfXXUwsQ=";
+      sha256 = "sha256-I/EXHGW92nXz6JCLp8SKGgzXrbbUTkLAfxv8bc/ThwQ=";
     };
-    date = "2026-08-24";
   };
   projects-yazi = {
     pname = "projects-yazi";
@@ -127,15 +124,14 @@
   };
   reverse-skill = {
     pname = "reverse-skill";
-    version = "37162cf9547c571c680c07005e9863d4610282dd";
+    version = "v1.0.1";
     src = fetchFromGitHub {
       owner = "zhaoxuya520";
       repo = "reverse-skill";
-      rev = "37162cf9547c571c680c07005e9863d4610282dd";
+      rev = "v1.0.1";
       fetchSubmodules = false;
-      sha256 = "sha256-dZ5PL7EeOxQVUI52nwFBlRG+9ZtA3ky2ccdAlILio58=";
+      sha256 = "sha256-jLcC22X7tRAHrW+B32PH+dID0tcVoUJ1CdBbS1SwNgY=";
     };
-    date = "2026-08-27";
   };
   yazi-plugins = {
     pname = "yazi-plugins";

--- a/flake.nix
+++ b/flake.nix
@@ -277,6 +277,7 @@
               prettier
               nixos-anywhere
               nvfetcher
+              actionlint
               # nh # 不要引入，会把nix放进来
               nix-prefetch-github
               nix-prefetch-git

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -29,9 +29,8 @@ src.branch   = "main"
 fetch.github = "forrestchang/andrej-karpathy-skills"
 
 [anti-slop]
-src.git      = "https://github.com/dmmulroy/anti-slop"
-src.branch   = "main"
-fetch.github = "dmmulroy/anti-slop"
+src.github_tag = "dmmulroy/anti-slop"
+fetch.github   = "dmmulroy/anti-slop"
 
 # [ai-design-skills]
 # src.git      = "https://github.com/elayadesign/ai-design-skills"
@@ -69,19 +68,17 @@ src.branch   = "main"
 fetch.github = "humanlayer/skills"
 
 [llamaparse-agent-skills]
-src.git      = "https://github.com/run-llama/llamaparse-agent-skills"
-src.branch   = "main"
-fetch.github = "run-llama/llamaparse-agent-skills"
+src.github_tag    = "run-llama/llamaparse-agent-skills"
+src.include_regex = "^liteparse-.*$"
+fetch.github      = "run-llama/llamaparse-agent-skills"
 
 [mattpocock-skills]
-src.git      = "https://github.com/mattpocock/skills"
-src.branch   = "main"
-fetch.github = "mattpocock/skills"
+src.github_tag = "mattpocock/skills"
+fetch.github   = "mattpocock/skills"
 
 [reverse-skill]
-src.git      = "https://github.com/zhaoxuya520/reverse-skill"
-src.branch   = "main"
-fetch.github = "zhaoxuya520/reverse-skill"
+src.github_tag = "zhaoxuya520/reverse-skill"
+fetch.github   = "zhaoxuya520/reverse-skill"
 
 # [redesign-skill]
 # src.git      = "https://github.com/elayadesign/redesign-skill"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,45 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended", ":dependencyDashboard"],
+  timezone: "Asia/Shanghai",
+  schedule: ["before 4am"],
+  labels: ["dependencies", "renovate"],
+  commitMessagePrefix: "chore(deps):",
+  commitMessageAction: "update",
+  rebaseWhen: "conflicted",
+  prConcurrentLimit: 10,
+  prHourlyLimit: 0,
+
+  nix: {
+    enabled: true,
+  },
+
+  packageRules: [
+    {
+      matchManagers: ["github-actions"],
+      pinDigests: true,
+      automerge: true,
+      automergeType: "pr",
+      platformAutomerge: true,
+      groupName: "GitHub Actions Dependencies",
+    },
+    {
+      matchManagers: ["nix"],
+      matchDepNames: [
+        "nixos/nixpkgs",
+        "nixpkgs",
+        "nixpkgs-darwin",
+        "nixpkgs-unstable",
+        "nix-darwin/nix-darwin",
+        "nix-community/home-manager",
+      ],
+      groupName: "Nix Core Inputs",
+      automerge: false,
+    },
+    {
+      matchManagers: ["nix"],
+      matchPackagePatterns: ["secrets", "dotfiles", "herdr"],
+      enabled: false,
+    },
+  ],
+}

--- a/scripts/renovate-skill-diff.py
+++ b/scripts/renovate-skill-diff.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import sys
 import urllib.parse
 import urllib.request
 
@@ -116,7 +117,10 @@ def main() -> None:
     parser.add_argument("--source", required=True)
     parser.add_argument("--pull-request", required=True)
     args = parser.parse_args()
-    token = os.environ["GITHUB_TOKEN"]
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        print("缺少 GitHub token，请设置 GITHUB_TOKEN 或 GH_TOKEN", file=sys.stderr)
+        raise SystemExit(1)
     body = report(read_json(args.base_file), read_json(args.head_file), args.source, token)
     if body:
         sync_comment(os.environ["GITHUB_REPOSITORY"], args.pull_request, body, token)

--- a/scripts/renovate-skill-diff.py
+++ b/scripts/renovate-skill-diff.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import urllib.parse
+import urllib.request
+
+MARKER = "<!-- renovate-skill-diff -->"
+RELEVANT_PATH_PARTS = ("SKILL.md", "skills/", "references/", "rules/")
+MAX_PATCH_LINES = 120
+MAX_PATCH_CHARS = 6000
+MAX_REPORT_CHARS = 60000
+
+
+def read_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as file:
+        return json.load(file)
+
+
+def github_json(method: str, url: str, token: str, payload: dict | None = None) -> dict | list:
+    data = None if payload is None else json.dumps(payload).encode()
+    headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    with urllib.request.urlopen(urllib.request.Request(url, data=data, headers=headers, method=method), timeout=20) as response:
+        return json.load(response)
+
+
+def repository(source: dict) -> tuple[str, str] | None:
+    src = source["src"]
+    if src.get("owner") and src.get("repo"):
+        return src["owner"], src["repo"]
+    url = src.get("url")
+    if not url:
+        return None
+    parts = urllib.parse.urlparse(url).path.strip("/").split("/")
+    if len(parts) < 2:
+        return None
+    return parts[0], parts[1].removesuffix(".git")
+
+
+def report(base: dict, head: dict, source_name: str, token: str) -> str:
+    before = base.get(source_name)
+    after = head.get(source_name)
+    if before == after:
+        return ""
+    sections = [MARKER, "## 📦 External Source & Skill Diff Report"]
+    if before is None:
+        sections.append(f"### `{source_name}` added at `{after['version']}`")
+        return "\n\n".join(sections)
+    if after is None:
+        sections.append(f"### `{source_name}` removed from `{before['version']}`")
+        return "\n\n".join(sections)
+
+    old_revision = before["src"].get("rev", before["version"])
+    new_revision = after["src"].get("rev", after["version"])
+    sections.append(f"### `{source_name}`: `{before['version']}` → `{after['version']}`")
+    source_repo = repository(after) or repository(before)
+    if source_repo is None or old_revision == new_revision:
+        return "\n\n".join(sections)
+    owner, repo = source_repo
+    compare_url = f"https://github.com/{owner}/{repo}/compare/{old_revision}...{new_revision}"
+    sections.append(f"🔗 [Full GitHub Comparison]({compare_url})")
+    comparison = github_json("GET", f"https://api.github.com/repos/{owner}/{repo}/compare/{old_revision}...{new_revision}", token)
+    if not isinstance(comparison, dict):
+        raise TypeError("GitHub compare response must be an object")
+    files = [file for file in comparison["files"] if any(part in file["filename"] for part in RELEVANT_PATH_PARTS)]
+    if not files:
+        sections.append("_No changes in `SKILL.md`, `skills/`, `references/`, or `rules/`._")
+        return "\n\n".join(sections)
+
+    sections.append("#### 📝 Detailed Skill & Rule Diffs")
+    for index, file in enumerate(files):
+        patch = file.get("patch", "")
+        lines = patch.splitlines()
+        if len(lines) > MAX_PATCH_LINES or len(patch) > MAX_PATCH_CHARS:
+            patch = "\n".join(lines[:MAX_PATCH_LINES])
+            suffix = f"\n\n_Diff truncated. [Open full file]({file['blob_url']})._"
+        else:
+            suffix = ""
+        section = (
+            f"<details><summary><b><code>{file['filename']}</code></b> ({file['status']}, +{file['additions']}, -{file['deletions']})</summary>\n\n"
+            f"```diff\n{patch}\n```{suffix}\n</details>"
+        )
+        if len("\n\n".join([*sections, section])) > MAX_REPORT_CHARS - 160:
+            sections.append(f"_{len(files) - index} additional skill/rule file diffs omitted. Use the comparison link above._")
+            break
+        sections.append(section)
+    return "\n\n".join(sections)
+
+
+def sync_comment(repository_name: str, pull_request: str, body: str, token: str) -> None:
+    page = 1
+    while True:
+        comments = github_json(
+            "GET",
+            f"https://api.github.com/repos/{repository_name}/issues/{pull_request}/comments?per_page=100&page={page}",
+            token,
+        )
+        if not isinstance(comments, list):
+            raise TypeError("GitHub comments response must be an array")
+        for comment in comments:
+            if comment["user"]["login"] == "github-actions[bot]" and MARKER in comment["body"]:
+                github_json("PATCH", f"https://api.github.com/repos/{repository_name}/issues/comments/{comment['id']}", token, {"body": body})
+                return
+        if len(comments) < 100:
+            break
+        page += 1
+    github_json("POST", f"https://api.github.com/repos/{repository_name}/issues/{pull_request}/comments", token, {"body": body})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-file", required=True)
+    parser.add_argument("--head-file", required=True)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--pull-request", required=True)
+    args = parser.parse_args()
+    token = os.environ["GITHUB_TOKEN"]
+    body = report(read_json(args.base_file), read_json(args.head_file), args.source, token)
+    if body:
+        sync_comment(os.environ["GITHUB_REPOSITORY"], args.pull_request, body, token)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-sources.py
+++ b/scripts/sync-sources.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""按源逐一运行 nvfetcher，为每个有上游更新的源创建独立分支、PR 与 diff 评论。
+
+sync 模式面向 CI：要求干净工作区与 origin/main 引用，使用 gh 与 GitHub API。
+dry-run 模式把 nvfetcher 输出到临时目录，只报告更新状态，不改动仓库任何文件。
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "nvfetcher.toml"
+GENERATED_JSON = ROOT / "_sources" / "generated.json"
+BRANCH_PREFIX = "automation/nvfetcher/"
+COMMITTER_NAME = "github-actions[bot]"
+COMMITTER_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+DIFF_SCRIPT = ROOT / "scripts" / "renovate-skill-diff.py"
+
+
+def run(*args: str) -> None:
+    subprocess.run(args, check=True, cwd=ROOT)
+
+
+def output(*args: str) -> str:
+    return subprocess.run(args, check=True, capture_output=True, text=True, cwd=ROOT).stdout.strip()
+
+
+def sources_from(config: Path) -> list[str]:
+    return list(tomllib.loads(config.read_text()))
+
+
+def changed_sources(baseline: dict, head: dict, source: str) -> list[str]:
+    changed = sorted(name for name in set(baseline) | set(head) if baseline.get(name) != head.get(name))
+    if changed != [source]:
+        raise ValueError(f"nvfetcher 单源过滤失效，期望只更新 {source}，实际变更：{changed}")
+    return changed
+
+
+def nvfetcher_run(config: Path, source: str, output_dir: Path) -> None:
+    subprocess.run(
+        ["nvfetcher", "-c", str(config), "-f", f"^{source}$", "-o", str(output_dir)],
+        check=True, cwd=ROOT,
+    )
+
+
+def remote_branch_exists(branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-remote", "--exit-code", "--heads", "origin", branch],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def gh_pr_number(branch: str) -> str:
+    repository = os.environ["GITHUB_REPOSITORY"]
+    return output(
+        "gh", "pr", "list", "--repo", repository, "--head", branch, "--state", "open",
+        "--json", "number", "--jq", ".[0].number // empty",
+    )
+
+
+def create_pull_request(branch: str, source: str) -> str:
+    repository = os.environ["GITHUB_REPOSITORY"]
+    return output(
+        "gh", "pr", "create", "--repo", repository, "--base", "main",
+        "--head", branch, "--title", f"chore(nvfetcher): update {source}",
+        "--body", f"Automated update of `{source}` via nvfetcher.",
+        "--json", "number", "--jq", ".number",
+    )
+
+
+def sync_comment(base_file: str, head_file: str, source: str, pull_request: str) -> None:
+    subprocess.run(
+        ["python3", str(DIFF_SCRIPT), "--base-file", base_file, "--head-file", head_file,
+         "--source", source, "--pull-request", pull_request],
+        check=True, env=dict(os.environ),
+    )
+
+
+def sync_source(source: str, config: Path, original_branch: str, baseline_json: str) -> None:
+    run("git", "restore", "--source=HEAD", "--", "_sources/generated.json", "_sources/generated.nix")
+    nvfetcher_run(config, source, ROOT / "_sources")
+    head_json = GENERATED_JSON.read_text()
+    baseline = json.loads(baseline_json)
+    head = json.loads(head_json)
+    if baseline.get(source) == head.get(source):
+        print(f"[{source}] up to date")
+        return
+    changed_sources(baseline, head, source)
+    before_version = baseline.get(source, {}).get("version", "(new)")
+    after_version = head[source]["version"]
+
+    branch = f"{BRANCH_PREFIX}{source}"
+    run("git", "switch", "-C", branch, "origin/main")
+    run("git", "add", "--", "_sources/generated.json", "_sources/generated.nix")
+    run("git", "-c", f"user.name={COMMITTER_NAME}", "-c", f"user.email={COMMITTER_EMAIL}",
+        "commit", "-m", f"chore(nvfetcher): update {source}")
+    if remote_branch_exists(branch):
+        run("git", "push", "--force", "origin", f"HEAD:{branch}")
+    else:
+        run("git", "push", "-u", "origin", f"HEAD:{branch}")
+    pull_request = gh_pr_number(branch) or create_pull_request(branch, source)
+    with tempfile.NamedTemporaryFile("w", suffix=".json") as base_tmp, tempfile.NamedTemporaryFile("w", suffix=".json") as head_tmp:
+        base_tmp.write(baseline_json)
+        head_tmp.write(head_json)
+        base_tmp.flush()
+        head_tmp.flush()
+        sync_comment(base_tmp.name, head_tmp.name, source, pull_request)
+    print(f"[{source}] updated {before_version} -> {after_version} via PR #{pull_request}")
+    run("git", "switch", original_branch)
+    run("git", "restore", "--source=HEAD", "--", "_sources/generated.json", "_sources/generated.nix")
+
+
+def check_source(source: str, config: Path, baseline_json: str) -> bool:
+    baseline = json.loads(baseline_json)
+    with tempfile.TemporaryDirectory() as tmp:
+        output_dir = Path(tmp)
+        shutil.copy(ROOT / "_sources" / "generated.json", output_dir / "generated.json")
+        shutil.copy(ROOT / "_sources" / "generated.nix", output_dir / "generated.nix")
+        nvfetcher_run(config, source, output_dir)
+        head = json.loads((output_dir / "generated.json").read_text())
+    if baseline.get(source) == head.get(source):
+        print(f"[{source}] up to date")
+        return False
+    changed_sources(baseline, head, source)
+    before_version = baseline.get(source, {}).get("version", "(new)")
+    after_version = head[source]["version"]
+    print(f"[{source}] would update {before_version} -> {after_version}")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, default=CONFIG, help="nvfetcher 配置文件")
+    parser.add_argument("--sources", help="逗号分隔的源名列表，缺省处理配置中全部源")
+    parser.add_argument("--dry-run", action="store_true", help="只报告更新状态，不改动 git 与仓库文件")
+    args = parser.parse_args()
+    config = args.config if args.config.is_absolute() else ROOT / args.config
+    sources = args.sources.split(",") if args.sources else sources_from(config)
+    baseline_json = GENERATED_JSON.read_text()
+
+    if args.dry_run:
+        for source in sources:
+            check_source(source, config, baseline_json)
+        return
+
+    original_branch = output("git", "branch", "--show-current")
+    if not original_branch:
+        print("sync 模式需要处于具名分支（CI 中为 main）", file=sys.stderr)
+        raise SystemExit(1)
+    if output("git", "status", "--porcelain"):
+        print("工作区不干净，拒绝运行", file=sys.stderr)
+        raise SystemExit(1)
+    failures = []
+    for source in sources:
+        try:
+            sync_source(source, config, original_branch, baseline_json)
+        except subprocess.CalledProcessError as error:
+            failures.append(f"{source}: {error}")
+            run("git", "switch", original_branch)
+            run("git", "restore", "--source=HEAD", "--", "_sources/generated.json", "_sources/generated.nix")
+    if failures:
+        print("以下源处理失败：", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_renovate_skill_diff.py
+++ b/scripts/tests/test_renovate_skill_diff.py
@@ -1,0 +1,116 @@
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("renovate_skill_diff", ROOT / "scripts/renovate-skill-diff.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+base = {
+    "demo-skill": {
+        "version": "v1.0.0",
+        "src": {"owner": "example", "repo": "demo-skill", "rev": "v1.0.0"},
+    },
+    "other-skill": {
+        "version": "v2.0.0",
+        "src": {"owner": "example", "repo": "other-skill", "rev": "v2.0.0"},
+    },
+}
+head = {
+    "demo-skill": {
+        "version": "v1.1.0",
+        "src": {"owner": "example", "repo": "demo-skill", "rev": "v1.1.0"},
+    },
+    "other-skill": {
+        "version": "v2.1.0",
+        "src": {"owner": "example", "repo": "other-skill", "rev": "v2.1.0"},
+    },
+}
+
+calls = []
+
+
+def compare_request(method, url, token, payload=None):
+    calls.append((method, url, token, payload))
+    assert method == "GET"
+    assert url == "https://api.github.com/repos/example/demo-skill/compare/v1.0.0...v1.1.0"
+    return {
+        "files": [
+            {
+                "filename": "skills/demo/SKILL.md",
+                "status": "modified",
+                "additions": 1,
+                "deletions": 1,
+                "patch": "@@ -1 +1 @@\n-old\n+new",
+                "blob_url": "https://example.test/SKILL.md",
+            },
+            {
+                "filename": "README.md",
+                "status": "modified",
+                "additions": 1,
+                "deletions": 0,
+                "patch": "+ignored",
+                "blob_url": "https://example.test/README.md",
+            },
+        ]
+    }
+
+
+module.github_json = compare_request
+body = module.report(base, head, "demo-skill", "token")
+assert module.MARKER in body
+assert "`demo-skill`: `v1.0.0` → `v1.1.0`" in body
+assert "https://github.com/example/demo-skill/compare/v1.0.0...v1.1.0" in body
+assert "skills/demo/SKILL.md" in body
+assert "README.md" not in body
+assert "other-skill" not in body
+assert len(calls) == 1
+assert module.report(base, base, "demo-skill", "token") == ""
+
+
+def failed_compare(*_args, **_kwargs):
+    raise RuntimeError("GitHub compare failed")
+
+
+module.github_json = failed_compare
+try:
+    module.report(base, head, "demo-skill", "token")
+except RuntimeError as error:
+    assert str(error) == "GitHub compare failed"
+else:
+    raise AssertionError("compare failure was hidden")
+
+requests = []
+
+
+def paginated_request(method, url, token, payload=None):
+    requests.append((method, url, payload))
+    if method == "GET" and url.endswith("page=1"):
+        return [{"id": index, "user": {"login": "someone"}, "body": "other"} for index in range(100)]
+    if method == "GET" and url.endswith("page=2"):
+        return [{"id": 9, "user": {"login": "github-actions[bot]"}, "body": module.MARKER}]
+    return {}
+
+
+module.github_json = paginated_request
+module.sync_comment("owner/repo", "42", body, "token")
+assert requests[0] == ("GET", "https://api.github.com/repos/owner/repo/issues/42/comments?per_page=100&page=1", None)
+assert requests[1] == ("GET", "https://api.github.com/repos/owner/repo/issues/42/comments?per_page=100&page=2", None)
+assert requests[-1] == ("PATCH", "https://api.github.com/repos/owner/repo/issues/comments/9", {"body": body})
+
+requests = []
+
+
+def create_request(method, url, token, payload=None):
+    requests.append((method, url, payload))
+    if method == "GET":
+        return []
+    return {}
+
+
+module.github_json = create_request
+module.sync_comment("owner/repo", "42", body, "token")
+assert requests == [
+    ("GET", "https://api.github.com/repos/owner/repo/issues/42/comments?per_page=100&page=1", None),
+    ("POST", "https://api.github.com/repos/owner/repo/issues/42/comments", {"body": body}),
+]

--- a/scripts/tests/test_sync_sources.py
+++ b/scripts/tests/test_sync_sources.py
@@ -1,0 +1,532 @@
+"""sync-sources.py 提交 / PR 编排测试与真实 Git 沙箱集成测试。
+
+纯标准库实现（unittest.mock、tempfile、subprocess），可直跑：
+
+    python3 scripts/tests/test_sync_sources.py
+
+覆盖：
+- 场景 A：上游有更新 + 首次创建 PR（新分支、提交身份/message、-u 推送、PR、评论、环境恢复）
+- 场景 B：上游有更新 + 远程分支与 PR 已存在（--force 推送、复用 PR）
+- 场景 C：源无更新（不触发任何 git/PR/评论操作）
+- 场景 D：单源不变量防御（changed_sources 抛出 ValueError）
+- 场景 E：执行异常后的清理保证（switch 回原分支 + restore 工作区）
+- test_git_commit_sandbox：真实 git 沙箱验证提交对象（作者、message、文件集合）
+- renovate-skill-diff CLI 端到端：评论内容、粘性 PATCH / POST、token 环境变量兼容
+"""
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest.mock as mock
+from contextlib import contextmanager
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sync_sources = load_module("sync_sources", ROOT / "scripts" / "sync-sources.py")
+diff = load_module("renovate_skill_diff", ROOT / "scripts" / "renovate-skill-diff.py")
+
+SOURCE = "demo-source"
+BRANCH = "automation/nvfetcher/demo-source"
+COMMITTER = "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+COMMIT_MSG = "chore(nvfetcher): update demo-source"
+
+BASELINE = {
+    "demo-source": {"version": "v1.0.0", "src": {"owner": "example", "repo": "demo-source", "rev": "v1.0.0"}},
+    "other-source": {"version": "v2.0.0", "src": {"owner": "example", "repo": "other-source", "rev": "v2.0.0"}},
+}
+HEAD = {
+    "demo-source": {"version": "v1.1.0", "src": {"owner": "example", "repo": "demo-source", "rev": "v1.1.0"}},
+    "other-source": {"version": "v2.0.0", "src": {"owner": "example", "repo": "other-source", "rev": "v2.0.0"}},
+}
+
+GIT_FILES = ("_sources/generated.json", "_sources/generated.nix")
+
+
+@contextmanager
+def patched(**replacements):
+    """临时替换 sync_sources 模块属性，退出时恢复原值。"""
+    originals = {name: getattr(sync_sources, name) for name in replacements}
+    for name, value in replacements.items():
+        setattr(sync_sources, name, value)
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(sync_sources, name, original)
+
+
+def never_called(*_args, **_kwargs):
+    raise AssertionError("该函数在此场景中不应当被调用")
+
+
+def git_op(call: tuple) -> bool:
+    return call[:1] == ("git",)
+
+
+def git_action(call: tuple) -> str:
+    return call[1]
+
+
+def commit_call() -> tuple:
+    return (
+        "git", "-c", "user.name=github-actions[bot]", "-c",
+        "user.email=41898282+github-actions[bot]@users.noreply.github.com",
+        "commit", "-m", COMMIT_MSG,
+    )
+
+
+def restore_call() -> tuple:
+    return ("git", "restore", "--source=HEAD", "--", *GIT_FILES)
+
+
+def index_of(calls, pattern):
+    found = [i for i, call in enumerate(calls) if call == pattern]
+    assert found, f"缺少 git 调用 {pattern!r}，实际调用：{calls}"
+    return found[0]
+
+
+def test_first_pr_flow():
+    """场景 A：上游有更新且无远程分支/PR → 新分支、提交、-u 推送、建 PR、评论、环境恢复。"""
+    git_calls = []
+    pr_calls = []
+    comment_calls = []
+
+    def record_run(*args):
+        git_calls.append(args)
+
+    def record_create(branch, source):
+        pr_calls.append((branch, source))
+        return "42"
+
+    def record_comment(base_file, head_file, source, pull_request):
+        with open(base_file, encoding="utf-8") as fh:
+            assert json.load(fh) == BASELINE
+        with open(head_file, encoding="utf-8") as fh:
+            assert json.load(fh) == HEAD
+        comment_calls.append((source, pull_request))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        generated = Path(tmp) / "generated.json"
+        generated.write_text(json.dumps(HEAD), encoding="utf-8")
+        with patched(
+            run=record_run,
+            output=never_called,
+            nvfetcher_run=lambda *_: None,
+            GENERATED_JSON=generated,
+            remote_branch_exists=lambda branch: False,
+            gh_pr_number=lambda branch: "",
+            create_pull_request=record_create,
+            sync_comment=record_comment,
+        ):
+            sync_sources.sync_source(SOURCE, Path(tmp) / "nvfetcher.toml", "main", json.dumps(BASELINE))
+
+    switch = index_of(git_calls, ("git", "switch", "-C", BRANCH, "origin/main"))
+    add = index_of(git_calls, ("git", "add", "--", *GIT_FILES))
+    commit = index_of(git_calls, commit_call())
+    push = index_of(git_calls, ("git", "push", "-u", "origin", "HEAD:" + BRANCH))
+    switch_back = index_of(git_calls, ("git", "switch", "main"))
+    assert git_calls[0] == restore_call(), "流程应以工作区预检 restore 开始"
+    assert git_calls[-1] == restore_call(), "流程应以工作区恢复 restore 结束"
+    assert switch < add < commit < push < switch_back < len(git_calls) - 1, git_calls
+    assert pr_calls == [(BRANCH, SOURCE)]
+    assert comment_calls == [(SOURCE, "42")]
+
+
+def test_sticky_existing_pr_flow():
+    """场景 B：远程分支与 PR 已存在 → --force 推送并复用已有 PR，不新建。"""
+    git_calls = []
+    pr_number_calls = []
+    create_calls = []
+    comment_calls = []
+
+    def record_run(*args):
+        git_calls.append(args)
+
+    def record_pr_number(branch):
+        pr_number_calls.append(branch)
+        return "42"
+
+    def record_create(branch, source):
+        create_calls.append((branch, source))
+        return "99"
+
+    def record_comment(base_file, head_file, source, pull_request):
+        comment_calls.append((source, pull_request))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        generated = Path(tmp) / "generated.json"
+        generated.write_text(json.dumps(HEAD), encoding="utf-8")
+        with patched(
+            run=record_run,
+            nvfetcher_run=lambda *_: None,
+            GENERATED_JSON=generated,
+            remote_branch_exists=lambda branch: True,
+            gh_pr_number=record_pr_number,
+            create_pull_request=record_create,
+            sync_comment=record_comment,
+        ):
+            sync_sources.sync_source(SOURCE, Path(tmp) / "nvfetcher.toml", "main", json.dumps(BASELINE))
+
+    push = index_of(git_calls, ("git", "push", "--force", "origin", "HEAD:" + BRANCH))
+    assert push < index_of(git_calls, ("git", "switch", "main")), git_calls
+    assert not any(git_action(call) == "push" and "-u" in call for call in git_calls), git_calls
+    assert pr_number_calls == [BRANCH]
+    assert create_calls == [], "已有 PR 时不应调用 create_pull_request"
+    assert comment_calls == [(SOURCE, "42")], "应复用已有 PR 号同步评论"
+
+
+def test_up_to_date_no_ops():
+    """场景 C：源无更新 → 除预检 restore 外不触发任何 git/PR/评论操作。"""
+    git_calls = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        generated = Path(tmp) / "generated.json"
+        generated.write_text(json.dumps(BASELINE), encoding="utf-8")
+        with patched(
+            run=lambda *args: git_calls.append(args),
+            nvfetcher_run=lambda *_: None,
+            GENERATED_JSON=generated,
+            remote_branch_exists=never_called,
+            gh_pr_number=never_called,
+            create_pull_request=never_called,
+            sync_comment=never_called,
+        ):
+            sync_sources.sync_source(SOURCE, Path(tmp) / "nvfetcher.toml", "main", json.dumps(BASELINE))
+
+    assert not any(git_action(call) in ("switch", "commit", "push") for call in git_calls), git_calls
+
+
+def test_single_source_invariant():
+    """场景 D：head 混入非预期源改动 → changed_sources 抛出 ValueError，不做任何提交/推送。"""
+    intruder_head = {
+        **HEAD,
+        "other-source": {"version": "v9.9.9", "src": {"owner": "example", "repo": "other-source", "rev": "v9.9.9"}},
+    }
+    git_calls = []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        generated = Path(tmp) / "generated.json"
+        generated.write_text(json.dumps(intruder_head), encoding="utf-8")
+        with patched(
+            run=lambda *args: git_calls.append(args),
+            nvfetcher_run=lambda *_: None,
+            GENERATED_JSON=generated,
+            remote_branch_exists=never_called,
+            gh_pr_number=never_called,
+            create_pull_request=never_called,
+            sync_comment=never_called,
+        ):
+            try:
+                sync_sources.sync_source(SOURCE, Path(tmp) / "nvfetcher.toml", "main", json.dumps(BASELINE))
+            except ValueError as error:
+                message = str(error)
+                assert "demo-source" in message and "other-source" in message, message
+            else:
+                raise AssertionError("混入其它源改动时 changed_sources 未抛出 ValueError")
+
+    assert not any(git_action(call) in ("switch", "commit", "push") for call in git_calls), git_calls
+
+    # 直接调用：仅目标源变化时应通过
+    assert sync_sources.changed_sources(BASELINE, HEAD, SOURCE) == [SOURCE]
+
+
+def test_failure_cleanup():
+    """场景 E：git push 失败 → main 循环确保 switch 回原分支并 restore 工作区文件。"""
+    git_calls = []
+
+    def record_run(*args):
+        git_calls.append(args)
+        if args[:2] == ("git", "push"):
+            raise subprocess.CalledProcessError(1, args)
+
+    def fake_output(*args):
+        if args[-1] == "--show-current":
+            return "main"
+        return ""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        config = Path(tmp) / "nvfetcher.toml"
+        generated = Path(tmp) / "generated.json"
+        generated.write_text(json.dumps(BASELINE), encoding="utf-8")
+
+        def nvfetcher_writes_head(*_args):
+            generated.write_text(json.dumps(HEAD), encoding="utf-8")
+
+        with patched(
+            run=record_run,
+            output=fake_output,
+            nvfetcher_run=nvfetcher_writes_head,
+            GENERATED_JSON=generated,
+            remote_branch_exists=lambda branch: False,
+            gh_pr_number=never_called,
+            create_pull_request=never_called,
+            sync_comment=never_called,
+        ):
+            with mock.patch("sys.argv", ["sync-sources.py", "--config", str(config), "--sources", SOURCE]):
+                try:
+                    sync_sources.main()
+                except SystemExit as exc:
+                    assert exc.code == 1
+                else:
+                    raise AssertionError("push 失败后 main 应以非零状态退出")
+
+    assert git_action(git_calls[-1]) == "restore", "失败后必须 restore 工作区"
+    assert git_calls[-2] == ("git", "switch", "main"), "失败后必须 switch 回原分支"
+    push_index = index_of(git_calls, ("git", "push", "-u", "origin", "HEAD:" + BRANCH))
+    assert index_of(git_calls, commit_call()) < push_index < len(git_calls) - 2, git_calls
+
+
+def test_git_commit_sandbox():
+    """真实 Git 沙箱：执行真实 switch/add/commit，核验提交对象身份、message 与文件集合。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        generated = repo / "_sources" / "generated.json"
+        generated_nix = repo / "_sources" / "generated.nix"
+        generated.parent.mkdir()
+        generated.write_text(json.dumps(BASELINE), encoding="utf-8")
+        generated_nix.write_text("generated = {}\n", encoding="utf-8")
+
+        def git(*args):
+            subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+        def git_out(*args):
+            return subprocess.run(
+                ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+            ).stdout
+
+        git("init", "-b", "main")
+        git("config", "user.name", "Local Tester")
+        git("config", "user.email", "tester@example.com")
+        git("config", "commit.gpgsign", "false")
+        git("add", "-A")
+        git("commit", "-m", "init baseline")
+        git("update-ref", "refs/remotes/origin/main", git_out("rev-parse", "HEAD").strip())
+
+        def nvfetcher_writes_head(*_args):
+            generated.write_text(json.dumps(HEAD), encoding="utf-8")
+            generated_nix.write_text("generated = { version = \"v1.1.0\"; }\n", encoding="utf-8")
+
+        push_calls = []
+        comment_calls = []
+
+        original_run = sync_sources.run
+
+        def sandbox_run(*args):
+            if args[:2] == ("git", "push"):
+                push_calls.append(args)
+                return
+            original_run(*args)
+
+        with patched(
+            ROOT=repo,
+            GENERATED_JSON=generated,
+            run=sandbox_run,
+            nvfetcher_run=nvfetcher_writes_head,
+            remote_branch_exists=lambda branch: False,
+            gh_pr_number=lambda branch: "",
+            create_pull_request=lambda branch, source: "7",
+            sync_comment=lambda *_args: comment_calls.append(_args),
+        ):
+            sync_sources.sync_source(SOURCE, Path(tmp) / "nvfetcher.toml", "main", json.dumps(BASELINE))
+
+        assert git_out("branch", "--show-current").strip() == "main", "处理完成后应回到原分支"
+        log = git_out("log", "-1", "--format=%an <%ae>|%s", BRANCH).strip()
+        assert log == f"{COMMITTER}|{COMMIT_MSG}", f"提交对象身份/message 不符：{log!r}"
+        files = git_out("diff-tree", "--no-commit-id", "--name-only", "-r", BRANCH).split()
+        assert files == list(GIT_FILES), f"提交文件集合不符：{files}"
+        assert git_out("status", "--porcelain") == "", "工作区不应有残留改动"
+        assert len(push_calls) == 1 and push_calls[0] == ("git", "push", "-u", "origin", "HEAD:" + BRANCH), push_calls
+        assert len(comment_calls) == 1
+
+
+def _skill_source(name: str, version: str) -> dict:
+    return {"version": version, "src": {"owner": "example", "repo": name, "rev": version}}
+
+
+def _write_diff_fixture(tmp) -> tuple[Path, Path]:
+    tmp = Path(tmp)
+    base = {"demo-skill": _skill_source("demo-skill", "v1.0.0"), "other-skill": _skill_source("other-skill", "v2.0.0")}
+    head = {"demo-skill": _skill_source("demo-skill", "v1.1.0"), "other-skill": _skill_source("other-skill", "v2.0.0")}
+    base_file = tmp / "base.json"
+    head_file = tmp / "head.json"
+    base_file.write_text(json.dumps(base), encoding="utf-8")
+    head_file.write_text(json.dumps(head), encoding="utf-8")
+    return base_file, head_file
+
+
+def _compare_response() -> dict:
+    return {
+        "files": [
+            {
+                "filename": "skills/demo/SKILL.md",
+                "status": "modified",
+                "additions": 1,
+                "deletions": 1,
+                "patch": "@@ -1 +1 @@\n-old\n+new",
+                "blob_url": "https://example.test/SKILL.md",
+            },
+            {
+                "filename": "README.md",
+                "status": "modified",
+                "additions": 1,
+                "deletions": 0,
+                "patch": "+ignored",
+                "blob_url": "https://example.test/README.md",
+            },
+        ]
+    }
+
+
+def _run_diff_cli(tmp: Path, comments_get, env_extra) -> list:
+    base_file, head_file = _write_diff_fixture(tmp)
+    requests = []
+
+    def fake_github_json(method, url, token, payload=None):
+        requests.append((method, url, token, payload))
+        if method == "GET":
+            if "/compare/" in url:
+                return _compare_response()
+            return comments_get
+        return {}
+
+    diff.github_json = fake_github_json
+    with mock.patch.dict(os.environ, env_extra), mock.patch(
+        "sys.argv",
+        [
+            "renovate-skill-diff.py",
+            "--base-file", str(base_file),
+            "--head-file", str(head_file),
+            "--source", "demo-skill",
+            "--pull-request", "42",
+        ],
+    ):
+        diff.main()
+    return requests
+
+
+def _body_of(requests) -> str:
+    write_call = next(req for req in requests if req[0] in ("PATCH", "POST"))
+    return write_call[3]["body"]
+
+
+def test_cli_sticky_patch():
+    """评论端到端：PR 已存在带标记的旧评论 → 单次 PATCH 更新；正文含 marker/链接/技能 diff，不含无关文件。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        marker_comment = [{"id": 9, "user": {"login": "github-actions[bot]"}, "body": diff.MARKER}]
+        requests = _run_diff_cli(
+            tmp,
+            marker_comment,
+            {"GITHUB_TOKEN": "tok", "GITHUB_REPOSITORY": "owner/repo"},
+        )
+
+    methods = [req[0] for req in requests]
+    assert methods == ["GET", "GET", "PATCH"], f"应复用旧评论只 PATCH 一次：{methods}"
+    assert requests[-1][2] == "tok"
+    body = _body_of(requests)
+    assert diff.MARKER in body
+    assert "`demo-skill`: `v1.0.0` → `v1.1.0`" in body
+    assert "https://github.com/example/demo-skill/compare/v1.0.0...v1.1.0" in body
+    assert "skills/demo/SKILL.md" in body
+    assert "README.md" not in body
+    assert "other-skill" not in body
+
+
+def test_cli_post_when_no_marker():
+    """评论端到端：无既有标记评论 → 走 POST 新建评论，正文同样完整。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        requests = _run_diff_cli(tmp, [], {"GITHUB_TOKEN": "tok", "GITHUB_REPOSITORY": "owner/repo"})
+
+    methods = [req[0] for req in requests]
+    assert methods == ["GET", "GET", "POST"], f"无旧评论时应 POST 新建：{methods}"
+    assert diff.MARKER in _body_of(requests)
+
+
+def test_token_env_compat():
+    """token 环境变量兼容：仅 GH_TOKEN 可用；两者皆缺时给出清晰错误并退出非零。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        base_file, head_file = _write_diff_fixture(tmp)
+
+        # 仅设置 GH_TOKEN → 流程可走通，token 正确透传
+        seen_tokens = []
+
+        def fake(method, url, token, payload=None):
+            seen_tokens.append(token)
+            if method == "GET" and "/compare/" in url:
+                return {"files": []}
+            if method == "GET":
+                return []
+            return {}
+
+        diff.github_json = fake
+        with mock.patch.dict(
+            os.environ,
+            {"GITHUB_TOKEN": "", "GH_TOKEN": "tok-gh", "GITHUB_REPOSITORY": "owner/repo"},
+        ), mock.patch(
+            "sys.argv",
+            ["renovate-skill-diff.py", "--base-file", str(base_file), "--head-file", str(head_file),
+             "--source", "demo-skill", "--pull-request", "42"],
+        ):
+            diff.main()
+        assert seen_tokens and all(token == "tok-gh" for token in seen_tokens), seen_tokens
+
+        # 两者皆缺 → SystemExit(1) 且 stderr 有提示
+        def never(*_args, **_kwargs):
+            raise AssertionError("缺少 token 时不应发起任何 API 调用")
+
+        diff.github_json = never
+        stderr = io.StringIO()
+        with mock.patch.dict(os.environ, {"GITHUB_TOKEN": "", "GH_TOKEN": ""}), mock.patch(
+            "sys.argv",
+            ["renovate-skill-diff.py", "--base-file", str(base_file), "--head-file", str(head_file),
+             "--source", "demo-skill", "--pull-request", "42"],
+        ), mock.patch("sys.stderr", stderr):
+            try:
+                diff.main()
+            except SystemExit as exc:
+                assert exc.code == 1
+            else:
+                raise AssertionError("缺少 token 时未以非零状态退出")
+        assert "GITHUB_TOKEN 或 GH_TOKEN" in stderr.getvalue()
+
+
+def main() -> None:
+    tests = [
+        test_first_pr_flow,
+        test_sticky_existing_pr_flow,
+        test_up_to_date_no_ops,
+        test_single_source_invariant,
+        test_failure_cleanup,
+        test_git_commit_sandbox,
+        test_cli_sticky_patch,
+        test_cli_post_when_no_marker,
+        test_token_env_compat,
+    ]
+    failures = []
+    for test in tests:
+        try:
+            test()
+        except Exception as error:  # noqa: BLE001 —— 直跑脚本，逐用例报告
+            failures.append((test.__name__, error))
+            print(f"FAIL {test.__name__}: {error!r}", file=sys.stderr)
+        else:
+            print(f"PASS {test.__name__}")
+    if failures:
+        print(f"{len(failures)}/{len(tests)} 个测试失败", file=sys.stderr)
+        raise SystemExit(1)
+    print(f"全部 {len(tests)} 个测试通过")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 背景

此前方案用 Renovate 正则中介驱动 nvfetcher 源更新，引入 `nvfetcher-versions.toml` 双文件维护、4 个 custom.regex manager 与 PR 触发式工作流。每次新增源要人工同步两个版本清单，架构复杂且违背 nvfetcher 原生单源更新能力。

## 变更

用原生 nvfetcher 单源 PR 流取代 Renovate 中介：

- 新增 `scripts/sync-sources.py`。逐源执行 `nvfetcher -c nvfetcher.toml -f '^源名$'`，每个有上游更新的源独立建分支、提交、创建 PR 并更新 diff 评论
- 新增 `.github/workflows/nvfetcher-sync.yml`。每日 04:00 Asia/Shanghai 定时运行
- 删除 `nvfetcher-versions.toml`、`nvfetcher-source.py` 及其测试、旧 PR 触发工作流
- `renovate.json5` 回归纯基础管理（github-actions pinning 与 flake inputs），排除 secrets、dotfiles、herdr
- 保留 4 源（anti-slop、llamaparse-agent-skills、mattpocock-skills、reverse-skill）git 分支追踪到 github_tag 的迁移

开发者只维护 `nvfetcher.toml` 单一文件。

## 验证

- 全量 dry-run 遍历 13 源零异常，检出 cursor-plugins、yazi-plugins 两个真实上游更新
- 单源过滤实测：篡改种子 `src.rev` 后 `nvfetcher -f '^anti-slop$'` 只改该源，其余 12 源保持 stale
- 单源过滤失效不变量有断言保护（多源同时变动直接报错）
- actionlint、单元测试、pre-commit 全部通过